### PR TITLE
Add support for win32unix vim installations

### DIFF
--- a/autoload/fuzzy/files.vim
+++ b/autoload/fuzzy/files.vim
@@ -30,7 +30,7 @@ if executable('fd')
         'gitignore': 'fd --type f -H -E .git',
     }
 else
-    if has('win32')
+    if has('win32') || has('win32unix')
         commands = {
             'default': 'powershell -command "gci . -r -n -File"',
         }


### PR DESCRIPTION
Previously, windows unix-like vim installations - like the vim version provided by Git for Windows - would fail to render a filelist using the "default" command when launching vim with Powershell.

When launching vim with Git Bash, the file-search works as intended.

Now, the "default" command checks for unix-like Windows vim versions.