### PR TITLE
Fix grepping for patterns containing "

### DIFF
--- a/autoload/fuzzy/ag.vim
+++ b/autoload/fuzzy/ag.vim
@@ -104,7 +104,7 @@ def AgJobStart(pattern: string)
         return
     endif
     job_running = 1
-    var cmd_str = printf(cmd, pattern, cwd)
+    var cmd_str = printf(cmd, escape(pattern, '"'), escape(cwd, '"'))
     jid = job_start(cmd_str, {
         out_cb: function('JobHandler'),
         out_mode: 'raw',


### PR DESCRIPTION
job_start() parses passed in command-line for parameters escaped with double quotes, so escape it in parameters when formatting external command.

Path is also affected and needs escaping.