### PR TITLE
Fix fuzzy#inbuffer.Start

### DIFF
--- a/autoload/fuzzy/inbuffer.vim
+++ b/autoload/fuzzy/inbuffer.vim
@@ -23,9 +23,9 @@ export def Start(...keyword: list<any>)
     })
 
     if len(keyword) > 0
-        popup.SetPrompt(winds[1], keyword[0])
+        popup.SetPrompt(winds.prompt, keyword[0])
     endif
-    # var menu_wid = winds[0]
+    # var menu_wid = winds.menu
     # var file = expand('%:p')
     # var ext = fnamemodify(file, ':e')
     # var ft = selector.GetFt(ext)


### PR DESCRIPTION
This was reporting that `1` was not a valid key on the dictionary, and
digging through the calls indicated that the correct option is now
`.prompt`.
