### PR TITLE
Fix incompatibility with vim-sleuth

### DIFF
--- a/autoload/fuzzy/ag.vim
+++ b/autoload/fuzzy/ag.vim
@@ -209,7 +209,7 @@ def Select(wid: number, result: list<any>)
     if path == v:null
         return
     endif
-    execute('edit ' .. path)
+    exe 'edit ' .. path
     exe 'norm! ' .. linenr .. 'G'
     exe 'norm! zz'
 enddef

--- a/autoload/fuzzy/files.vim
+++ b/autoload/fuzzy/files.vim
@@ -46,7 +46,7 @@ def Select(wid: number, result: list<any>)
     if enable_devicons
         path = strcharpart(path, devicon_char_width + 1)
     endif
-    execute('edit ' .. path)
+    exe 'edit ' .. path
 enddef
 
 def AsyncCb(result: list<any>)

--- a/autoload/fuzzy/mru.vim
+++ b/autoload/fuzzy/mru.vim
@@ -48,7 +48,7 @@ def Close(wid: number, result: dict<any>)
         if enable_devicons
             path = strcharpart(path, devicon_char_width + 1)
         endif
-        execute('edit ' .. path)
+        exe 'edit ' .. path
     endif
 enddef
 


### PR DESCRIPTION
When vim-sleuth plugin is used, selecting a file to edit from fuzzyy results in error E930: Cannot use :redir inside execute(), e.g.

    Error detected while processing function <SNR>153_MenuFilter[28]..<SNR>153_GeneralPopupCallback[17]..<SNR>61_Select[5]..BufRead Autocommands for "*"..function <SNR>115_AutoInit[1]..<SNR>115_Init[15]..<SNR
    >115_DetectDeclared[21]..<SNR>115_ModelineOptions[2]..<SNR>115_Capture:
    line    1:
    E930: Cannot use :redir inside execute()
    Error detected while processing function <SNR>153_MenuFilter[28]..<SNR>153_GeneralPopupCallback[17]..<SNR>61_Select[5]..BufRead Autocommands for "*"..function <SNR>115_AutoInit[1]..<SNR>115_Init[15]..<SNR
    >115_DetectDeclared:
    line   21:
    E712: Argument of extend() must be a List or Dictionary

Fix using `:execute` rather than `execute()`, seems to work fine, can't find anything in the commit history to suggest the function was needed.

Alternative solution would be to use `execute('silent! edit ' .. path)`