### PR TITLE
Add FuzzyGrepRoot, FuzzyFilesRoot, and FuzzyMruRoot commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ git clone https://github.com/Donaldttt/fuzzyy ~/.vim/pack/Donaldttt/start/fuzzyy
 | FuzzyInBuffer \<str>  | search for string in buffer, use \<str> if provided   | \<leader>fi     |
 | FuzzyHelp             | search subjects/tags in :help documents               | \<leader>fh     |
 | FuzzyCommands         | search commands                                       | \<leader>fc     |
+| FuzzyFilesRoot        | search files in the project/vcs root directory        | None    |
+| FuzzyGrepRoot \<str>  | search for string in the project/vcs root directory   | None    |
 | FuzzyColors           | search installed color schemes                        | None    |
 | FuzzyCmdHistory       | search command history                                | None    |
 | FuzzyHighlights       | search highlight groups                               | None    |
@@ -166,6 +168,14 @@ let g:fuzzyy_include_hidden = 1
 let g:fuzzyy_follow_symlinks = 0
 " This option can also be set specifically for FuzzyFiles and/or FuzzyGrep using
 " g:fuzzyy_files_follow_symlinks and g:fuzzyy_grep_follow_symlinks
+
+" Patterns to identify a root directory for FuzzyFilesRoot and FuzzyGrepRoot
+" These commands find a "root" directory to use as the working directory by
+" walking up the direcrory tree looking for any match of these glob patterns.
+" Default is intentionally conservative, using common VCS root markers only
+let g:fuzzyy_root_patterns = ['.git', '.hg', '.svn']
+" Example usage
+let g:fuzzyy_root_patterns = ['.git', 'package.json', 'pyproject.toml']
 
 " Make FuzzyFiles, FuzzyGrep, and FuzzyMru always exclude files/directories
 " This applies whether .gitignore is respected or not

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ git clone https://github.com/Donaldttt/fuzzyy ~/.vim/pack/Donaldttt/start/fuzzyy
 | FuzzyCommands         | search commands                                       | \<leader>fc     |
 | FuzzyFilesRoot        | search files in the project/vcs root directory        | None    |
 | FuzzyGrepRoot \<str>  | search for string in the project/vcs root directory   | None    |
+| FuzzyMruRoot          | search most recent used files in project/vcs root     | None    |
 | FuzzyColors           | search installed color schemes                        | None    |
 | FuzzyCmdHistory       | search command history                                | None    |
 | FuzzyHighlights       | search highlight groups                               | None    |
@@ -169,7 +170,7 @@ let g:fuzzyy_follow_symlinks = 0
 " This option can also be set specifically for FuzzyFiles and/or FuzzyGrep using
 " g:fuzzyy_files_follow_symlinks and g:fuzzyy_grep_follow_symlinks
 
-" Patterns to identify a root directory for FuzzyFilesRoot and FuzzyGrepRoot
+" Patterns to find a project root in supported commands, e.g. FuzzyFilesRoot
 " These commands find a "root" directory to use as the working directory by
 " walking up the direcrory tree looking for any match of these glob patterns.
 " Default is intentionally conservative, using common VCS root markers only

--- a/autoload/fuzzyy/files.vim
+++ b/autoload/fuzzyy/files.vim
@@ -44,10 +44,11 @@ def ProcessResult(list_raw: list<string>, ...args: list<any>): list<string>
 enddef
 
 def Select(wid: number, result: list<any>)
-    var path = result[0]
+    var relative_path = result[0]
     if enable_devicons
-        path = strcharpart(path, devicon_char_width + 1)
+        relative_path = strcharpart(relative_path, devicon_char_width + 1)
     endif
+    var path = cwd .. '/' .. relative_path
     selector.MoveToUsableWindow()
     exe 'edit ' .. path
 enddef
@@ -97,7 +98,8 @@ def Preview(wid: number, opts: dict<any>)
         return
     endif
     var preview_wid = opts.win_opts.partids['preview']
-    if !filereadable(result)
+    var path = cwd .. '/' .. result
+    if !filereadable(path)
         if result == ''
             popup_settext(preview_wid, '')
         else
@@ -106,10 +108,10 @@ def Preview(wid: number, opts: dict<any>)
         return
     endif
     var preview_bufnr = winbufnr(preview_wid)
-    var fileraw = readfile(result, '', 1000)
+    var fileraw = readfile(path, '', 1000)
     noautocmd call popup_settext(preview_wid, fileraw)
     win_execute(preview_wid, 'norm gg')
-    win_execute(preview_wid, 'silent! doautocmd filetypedetect BufNewFile ' .. result)
+    win_execute(preview_wid, 'silent! doautocmd filetypedetect BufNewFile ' .. path)
     noautocmd win_execute(preview_wid, 'silent! setlocal nospell nolist')
 enddef
 
@@ -192,7 +194,7 @@ export def Start(opts: dict<any> = {})
     cur_result = []
     cur_pattern = ''
     last_pattern = '@!#-='
-    cwd = getcwd()
+    cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
     cwdlen = len(cwd)
     in_loading = 1
     var wids = selector.Start([], extend(opts, {

--- a/autoload/fuzzyy/utils/selector.vim
+++ b/autoload/fuzzyy/utils/selector.vim
@@ -310,6 +310,8 @@ def CloseTab(wid: number, result: dict<any>)
             # for special buffers that cannot be edited
             execute 'tabnew'
             execute 'buffer ' .. bufnr
+        elseif cwd ==# getcwd()
+            execute 'tabnew ' .. buf
         else
             var path = cwd .. '/' .. buf
             execute 'tabnew ' .. path
@@ -331,6 +333,8 @@ def CloseVSplit(wid: number, result: dict<any>)
         if bufnr > 0
             # for special buffers that cannot be edited
             execute 'vert sb ' .. bufnr
+        elseif cwd ==# getcwd()
+            execute 'vsp ' .. buf
         else
             var path = cwd .. '/' .. buf
             execute 'vsp ' .. path
@@ -352,6 +356,8 @@ def CloseSplit(wid: number, result: dict<any>)
         if bufnr > 0
             # for special buffers that cannot be edited
             execute 'sb ' .. bufnr
+        elseif cwd ==# getcwd()
+            execute 'sp ' .. buf
         else
             var path = cwd .. '/' .. buf
             execute 'sp ' .. path

--- a/plugin/fuzzyy.vim
+++ b/plugin/fuzzyy.vim
@@ -116,6 +116,7 @@ command! -nargs=0 FuzzyGitFiles files.Start(extendnew(windows.files, { 'command'
 command! -nargs=0 FuzzyCmdHistory cmdhistory.Start(windows.cmdhistory)
 command! -nargs=0 FuzzyMru mru.Start(windows.mru)
 command! -nargs=0 FuzzyMruCwd mru.Start(extendnew(windows.mru, { 'cwd': getcwd() }))
+command! -nargs=0 FuzzyMruRoot mru.Start(extendnew(windows.mru, { 'cwd': selector.GetRootDir() }))
 
 # Deprecated/renamed commands
 def Warn(msg: string)

--- a/plugin/fuzzyy.vim
+++ b/plugin/fuzzyy.vim
@@ -100,19 +100,22 @@ import autoload '../autoload/fuzzyy/buffers.vim'
 import autoload '../autoload/fuzzyy/highlights.vim'
 import autoload '../autoload/fuzzyy/cmdhistory.vim'
 import autoload '../autoload/fuzzyy/mru.vim'
+import autoload '../autoload/fuzzyy/utils/selector.vim'
 
-command! -nargs=? FuzzyGrep grep.Start(extend(windows.grep, { 'search': <q-args> }))
+command! -nargs=? FuzzyGrep grep.Start(extendnew(windows.grep, { 'search': <q-args> }))
+command! -nargs=? FuzzyGrepRoot grep.Start(extendnew(windows.grep, { 'cwd': selector.GetRootDir(), 'search': <q-args> }))
 command! -nargs=0 FuzzyFiles files.Start(windows.files)
+command! -nargs=? FuzzyFilesRoot files.Start(extendnew(windows.files, { 'cwd': selector.GetRootDir() }))
 command! -nargs=0 FuzzyHelp help.Start(windows.help)
 command! -nargs=0 FuzzyColors colors.Start(windows.colors)
-command! -nargs=? FuzzyInBuffer inbuffer.Start(extend(windows.inbuffer, { 'search': <q-args> }))
+command! -nargs=? FuzzyInBuffer inbuffer.Start(extendnew(windows.inbuffer, { 'search': <q-args> }))
 command! -nargs=0 FuzzyCommands commands.Start(windows.commands)
 command! -nargs=0 FuzzyBuffers buffers.Start(windows.buffers)
 command! -nargs=0 FuzzyHighlights highlights.Start(windows.highlights)
-command! -nargs=0 FuzzyGitFiles files.Start(extend(windows.files, { 'command': 'git ls-files' }))
+command! -nargs=0 FuzzyGitFiles files.Start(extendnew(windows.files, { 'command': 'git ls-files' }))
 command! -nargs=0 FuzzyCmdHistory cmdhistory.Start(windows.cmdhistory)
 command! -nargs=0 FuzzyMru mru.Start(windows.mru)
-command! -nargs=0 FuzzyMruCwd mru.Start(extend(windows.mru, { 'cwd': getcwd() }))
+command! -nargs=0 FuzzyMruCwd mru.Start(extendnew(windows.mru, { 'cwd': getcwd() }))
 
 # Deprecated/renamed commands
 def Warn(msg: string)


### PR DESCRIPTION
This adds variants of FuzzyGrep, FuzzyFiles, and FuzzyMru commands to search within the "project" root, initially by simply looking for known source control root markers in the filesystem, but could be extended with other checks.

The default root patterns are intentionally conservative, not including patterns specific to build and packaging tools, programming languages, editors etc. as it's very difficult to set defaults including these things that are both widely applicable and will stand the test of time. Some code repositories also contain multiple packages, so even defining what is a project is not always obvious, probably best left to users.

A possibly unobvious, but positive, side-effect of these changes is that they make it possible to pass an arbitrary `cwd` option to any of the grep, files, or mru selectors. 
