### PR TITLE
better deprecation warnings

### DIFF
--- a/autoload/fuzzyy/utils/selector.vim
+++ b/autoload/fuzzyy/utils/selector.vim
@@ -403,11 +403,6 @@ export def Start(li_raw: list<string>, opts: dict<any>): dict<any>
     if popup.active
         return { 'menu': -1, 'prompt': -1, 'preview': -1 }
     endif
-    if exists('g:__fuzzyy_warnings_found') && g:__fuzzyy_warnings_found
-        echohl WarningMsg
-        echow 'Fuzzyy started with warnings, use :FuzzyShowWarnings command to see details'
-        echohl None
-    endif
     cwd = getcwd()
     prompt_str = ''
 
@@ -428,6 +423,12 @@ export def Start(li_raw: list<string>, opts: dict<any>): dict<any>
     popup.MenuSetText(li)
     if enable_devicons
         devicons.AddColor(menu_wid)
+    endif
+
+    if exists('g:__fuzzyy_warnings_found') && g:__fuzzyy_warnings_found
+        echohl WarningMsg
+        echo 'Fuzzyy started with warnings, use :FuzzyShowWarnings command to see details'
+        echohl None
     endif
 
     autocmd User PopupClosed ++once Cleanup()


### PR DESCRIPTION
Move the code to show the warning to after the popups have been created,
which avoids the "Press ENTER or type command to continue" prompt when
the width of the message is wider than the current window (by the time
the message is echoed the current window is the fuzzyy prompt window)

But retain then use of echow for warnings re deprecated commands. These
warnings should only be shown when running the deprecated command, not
included in the shared list of deprecations for configuration options,
but we still need to avoid "Press ENTER or type command to continue".

We could pass the relevant warning(s) to selector.Start() and only show
one message, but that seems an overly complex solution to this problem,
and the combination of echow and echo actually works quite nicely.
