### PR TITLE
Do not overwrite any existing leader mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ nnoremap <silent> <leader>fm :FuzzyMru<CR>
 nnoremap <silent> <leader>fr :FuzzyMruCwd<CR>
 ```
 
+Fuzzyy will not overwrite any existing mappings from your vimrc when adding
+default mappings
+
 ## Options
 
 ```vim

--- a/plugin/fuzzyy.vim
+++ b/plugin/fuzzyy.vim
@@ -139,12 +139,19 @@ if len(warnings) > 0
 endif
 
 if g:fuzzyy_enable_mappings
-    nnoremap <silent> <leader>fb :FuzzyBuffers<CR>
-    nnoremap <silent> <leader>fc :FuzzyCommands<CR>
-    nnoremap <silent> <leader>ff :FuzzyFiles<CR>
-    nnoremap <silent> <leader>fg :FuzzyGrep<CR>
-    nnoremap <silent> <leader>fh :FuzzyHelp<CR>
-    nnoremap <silent> <leader>fi :FuzzyInBuffer<CR>
-    nnoremap <silent> <leader>fm :FuzzyMru<CR>
-    nnoremap <silent> <leader>fr :FuzzyMruCwd<CR>
+    var mappings = {
+        '<leader>fb': ':FuzzyBuffers<CR>',
+        '<leader>fc': ':FuzzyCommands<CR>',
+        '<leader>ff': ':FuzzyFiles<CR>',
+        '<leader>fg': ':FuzzyGrep<CR>',
+        '<leader>fh': ':FuzzyHelp<CR>',
+        '<leader>fi': ':FuzzyInBuffer<CR>',
+        '<leader>fm': ':FuzzyMru<CR>',
+        '<leader>fr': ':FuzzyMruCwd<CR>'
+    }
+    for [lhs, rhs] in items(mappings)
+        if empty(maparg(lhs, 'n'))
+            exe 'nnoremap <silent> ' .. lhs .. ' ' .. rhs
+        endif
+    endfor
 endif


### PR DESCRIPTION
Avoids breaking any custom configuration in a user's vimrc when adding
the fuzzyy leader mappings (also allows users to remap fuzzyy mappings)
