### PR TITLE
Add FuzzyTags and FuzzyTagsRoot commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ git clone https://github.com/Donaldttt/fuzzyy ~/.vim/pack/Donaldttt/start/fuzzyy
 | FuzzyCommands         | search commands                                       | \<leader>fc     |
 | FuzzyFilesRoot        | search files in the project/vcs root directory        | None    |
 | FuzzyGrepRoot \<str>  | search for string in the project/vcs root directory   | None    |
-| FuzzyMruRoot          | search most recent used files in project/vcs root     | None    |
 | FuzzyColors           | search installed color schemes                        | None    |
 | FuzzyCmdHistory       | search command history                                | None    |
 | FuzzyHighlights       | search highlight groups                               | None    |
 | FuzzyTags             | search tags, requires [ctags][], see `:h tags`        | None    |
+| FuzzyTagsRoot         | search tags in the project/vcs root directory         | None    |
 | FuzzyGitFiles         | search files in output from `git ls-files`            | None    |
 | FuzzyHelps            | deprecated alias for FuzzyHelp, will be removed       | None    |
 | FuzzyMRUFiles         | deprecated alias for FuzzyMru, will be removed        | None    |

--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ git clone https://github.com/Donaldttt/fuzzyy ~/.vim/pack/Donaldttt/start/fuzzyy
 | FuzzyColors           | search installed color schemes                        | None    |
 | FuzzyCmdHistory       | search command history                                | None    |
 | FuzzyHighlights       | search highlight groups                               | None    |
+| FuzzyTags             | search tags, requires [ctags][], see `:h tags`        | None    |
 | FuzzyGitFiles         | search files in output from `git ls-files`            | None    |
 | FuzzyHelps            | deprecated alias for FuzzyHelp, will be removed       | None    |
 | FuzzyMRUFiles         | deprecated alias for FuzzyMru, will be removed        | None    |
+
+[ctags]: https://ctags.io/
 
 - For FuzzyGrep and FuzzyInBuffer, you can define a keymap like this to search the
 word under cursor.
@@ -97,10 +100,10 @@ be used to scroll the preview window, but not the menu window.
 - FuzzyHighlights
     - `ctrl + k` toggle white preview background color
 
-- FuzzyMru, FuzzyMruCwd
+- FuzzyMru
     - `ctrl + k` toggle between all MRU files and CWD only
 
-- FuzzyBuffers, FuzzyFiles, FuzzyGitFiles, FuzzyGrep, FuzzyMru, FuzzyMruCwd
+- FuzzyBuffers, FuzzyFiles, FuzzyGrep, FuzzyMru, FuzzyTags
     - `ctrl + s` open selected file in horizontal split
     - `ctrl + v` open selected file in vertical split
     - `ctrl + t` open selected file in new tab page
@@ -253,6 +256,7 @@ let g:fuzzyy_buffers_keymap = {
 \    'grep': {},
 \    'buffers': {},
 \    'mru': {},
+\    'tags': {},
 \    'highlights': {},
 \    'cmdhistory': {
 \        'width': 0.6,

--- a/autoload/fuzzyy/tags.vim
+++ b/autoload/fuzzyy/tags.vim
@@ -23,8 +23,7 @@ def Select(wid: number, result: list<any>)
     if filereadable(tagfile)
         selector.MoveToUsableWindow()
         exe 'edit ' .. tagfile
-        feedkeys(':' .. tagaddress .. "\<CR>", 'n')
-        exe 'norm! zz'
+        feedkeys(':' .. tagaddress .. "\<CR>:norm! zz\<CR>", 'n')
     endif
 enddef
 
@@ -33,8 +32,7 @@ def CloseTab(wid: number, result: dict<any>)
         var [tagname, tagfile, tagaddress] = ParseResult(result.cursor_item)
         if filereadable(tagfile)
             exe 'tabnew ' .. tagfile
-            feedkeys(':' .. tagaddress .. "\<CR>", 'n')
-            exe 'norm! zz'
+            feedkeys(':' .. tagaddress .. "\<CR>:norm! zz\<CR>", 'n')
         endif
     endif
 enddef
@@ -44,8 +42,7 @@ def CloseVSplit(wid: number, result: dict<any>)
         var [tagname, tagfile, tagaddress] = ParseResult(result.cursor_item)
         if filereadable(tagfile)
             exe 'vsplit ' .. tagfile
-            feedkeys(':' .. tagaddress .. "\<CR>", 'n')
-            exe 'norm! zz'
+            feedkeys(':' .. tagaddress .. "\<CR>:norm! zz\<CR>", 'n')
         endif
     endif
 enddef
@@ -55,8 +52,7 @@ def CloseSplit(wid: number, result: dict<any>)
         var [tagname, tagfile, tagaddress] = ParseResult(result.cursor_item)
         if filereadable(tagfile)
             exe 'split ' .. tagfile
-            feedkeys(':' .. tagaddress .. "\<CR>", 'n')
-            exe 'norm! zz'
+            feedkeys(':' .. tagaddress .. "\<CR>:norm! zz\<CR>", 'n')
         endif
     endif
 enddef

--- a/autoload/fuzzyy/tags.vim
+++ b/autoload/fuzzyy/tags.vim
@@ -1,0 +1,176 @@
+vim9script
+
+import autoload './utils/selector.vim'
+
+var tag_list: list<string>
+
+def ParseResult(result: string): list<any>
+    # Tags file format, see https://docs.ctags.io/en/latest/man/tags.5.html
+    # {tagname}<Tab>{tagfile}<Tab>{tagaddress}[;"<Tab>{tagfield}..]
+    var parts = result->split("\t")
+    var [tagname, tagfile] = parts[0 : 1]
+    var rest = parts[2 : -1]->join("\t")
+    var tagaddress = rest->split(';"\t')[0]
+    return [tagname, tagfile, tagaddress]
+enddef
+
+def EscQuotes(str: string): string
+    return substitute(str, "'", "''", 'g')
+enddef
+
+def Select(wid: number, result: list<any>)
+    var [tagname, tagfile, tagaddress] = ParseResult(result[0])
+    if filereadable(tagfile)
+        selector.MoveToUsableWindow()
+        exe 'edit ' .. tagfile
+        feedkeys(':' .. tagaddress .. "\<CR>", 'n')
+        exe 'norm! zz'
+    endif
+enddef
+
+def CloseTab(wid: number, result: dict<any>)
+    if has_key(result, 'cursor_item')
+        var [tagname, tagfile, tagaddress] = ParseResult(result.cursor_item)
+        if filereadable(tagfile)
+            exe 'tabnew ' .. tagfile
+            feedkeys(':' .. tagaddress .. "\<CR>", 'n')
+            exe 'norm! zz'
+        endif
+    endif
+enddef
+
+def CloseVSplit(wid: number, result: dict<any>)
+    if has_key(result, 'cursor_item')
+        var [tagname, tagfile, tagaddress] = ParseResult(result.cursor_item)
+        if filereadable(tagfile)
+            exe 'vsplit ' .. tagfile
+            feedkeys(':' .. tagaddress .. "\<CR>", 'n')
+            exe 'norm! zz'
+        endif
+    endif
+enddef
+
+def CloseSplit(wid: number, result: dict<any>)
+    if has_key(result, 'cursor_item')
+        var [tagname, tagfile, tagaddress] = ParseResult(result.cursor_item)
+        if filereadable(tagfile)
+            exe 'split ' .. tagfile
+            feedkeys(':' .. tagaddress .. "\<CR>", 'n')
+            exe 'norm! zz'
+        endif
+    endif
+enddef
+
+def SetVSplitClose()
+    selector.ReplaceCloseCb(function('CloseVSplit'))
+    selector.Close()
+enddef
+
+def SetSplitClose()
+    selector.ReplaceCloseCb(function('CloseSplit'))
+    selector.Close()
+enddef
+
+def SetTabClose()
+    selector.ReplaceCloseCb(function('CloseTab'))
+    selector.Close()
+enddef
+
+var split_edit_callbacks = {
+    "\<c-v>": function('SetVSplitClose'),
+    "\<c-s>": function('SetSplitClose'),
+    "\<c-t>": function('SetTabClose'),
+}
+
+def Preview(wid: number, opts: dict<any>)
+    var result = opts.cursor_item
+    if !has_key(opts.win_opts.partids, 'preview')
+        return
+    endif
+    var preview_wid = opts.win_opts.partids['preview']
+    if result == ''
+        popup_settext(preview_wid, '')
+        return
+    endif
+    win_execute(preview_wid, 'syntax clear')
+    var [tagname, tagfile, tagaddress] = ParseResult(result)
+    if !filereadable(tagfile)
+        if result == ''
+            popup_settext(preview_wid, '')
+        else
+            popup_settext(preview_wid, tagfile .. ' not found')
+        endif
+        return
+    endif
+    var preview_bufnr = winbufnr(preview_wid)
+    noautocmd call popup_settext(preview_wid, readfile(tagfile))
+    win_execute(preview_wid, 'silent! doautocmd filetypedetect BufNewFile ' .. tagfile)
+    noautocmd win_execute(preview_wid, 'silent! setlocal nospell nolist')
+    for excmd in tagaddress->split(";")
+        if trim(excmd) =~ '^\d\+$'
+            win_execute(preview_wid, "silent! cursor(" .. excmd .. ", 1)")
+        else
+            var pattern = excmd->substitute('^\/', '', '')->substitute('\M\/;\?"\?$', '', '')
+            win_execute(preview_wid, "silent! search('\\M" .. EscQuotes(pattern) .. "', 'cw')")
+            clearmatches(preview_wid)
+            win_execute(preview_wid, "silent! matchadd('fuzzyyPreviewMatch', '\\M" .. EscQuotes(pattern) .. "')")
+        endif
+    endfor
+    win_execute(preview_wid, 'norm! zz')
+enddef
+
+def AsyncCb(result: list<any>)
+    var strs = []
+    var hl_list = []
+    var idx = 1
+    for item in result
+        add(strs, item[0])
+        hl_list += reduce(item[1], (acc, val) => {
+            add(acc, [idx] + val)
+            return acc
+        }, [])
+        idx += 1
+    endfor
+    selector.UpdateMenu(strs, hl_list)
+enddef
+
+def Input(wid: number, args: dict<any>, ...li: list<any>)
+    var pattern = args.str
+    selector.FuzzySearchAsync(tag_list, pattern, 200, function('AsyncCb'))
+enddef
+
+export def Start(opts: dict<any> = {})
+    if empty(tagfiles())
+        # copied from fzf.vim, thanks @junegunn
+        inputsave()
+        echohl WarningMsg
+        var gen = input('No tags file found. Generate? (y/N) ')
+        echohl None
+        inputrestore()
+        redraw
+        if gen =~? '^y'
+            var is_win = has('win32') || has('win64')
+            system('ctags -R' .. (is_win ? ' --output-format=e-ctags' : ''))
+            if empty(tagfiles())
+                echoerr 'Failed to create tags file'
+            else
+                echo 'Created tags file'
+            endif
+        endif
+    endif
+
+    tag_list = []
+    # Possible TODO: use readtags program here, would remove additional info
+    # and could also be used to format the lines nicely (fzf.vim does this)
+    for path in tagfiles()
+        var lines = readfile(path)
+        tag_list += lines[match(lines, '^[^!]') : -1]
+    endfor
+
+    var wids = selector.Start(tag_list, extend(opts, {
+        select_cb: function('Select'),
+        preview_cb: function('Preview'),
+        input_cb: function('Input'),
+        key_callbacks: split_edit_callbacks,
+    }))
+enddef

--- a/autoload/fuzzyy/tags.vim
+++ b/autoload/fuzzyy/tags.vim
@@ -140,18 +140,31 @@ export def Start(opts: dict<any> = {})
         # copied from fzf.vim, thanks @junegunn
         inputsave()
         echohl WarningMsg
-        var gen = input('No tags file found. Generate? (y/N) ')
+        var gen = input('No tags file in ' .. fnamemodify(getcwd(), ':~') .. ', generate? (y/N) ')
         echohl None
         inputrestore()
         redraw
         if gen =~? '^y'
-            var is_win = has('win32') || has('win64')
-            system('ctags -R' .. (is_win ? ' --output-format=e-ctags' : ''))
+            if ! executable('ctags')
+                echoerr "Missing executable ctags, please install Universal Ctags"
+                return
+            else
+                var ver = system('ctags --version')
+                if ver !~? "Universal"
+                    echoerr "Incompatible ctags version, please install Universal Ctags"
+                    return
+                endif
+            endif
+            var out = system('ctags -R')
             if empty(tagfiles())
-                echoerr 'Failed to create tags file'
+                echoerr 'Failed to create tags file: ' .. out
+                return
             else
                 echo 'Created tags file'
             endif
+        else
+            echo ''
+            return
         endif
     endif
 

--- a/autoload/fuzzyy/utils/selector.vim
+++ b/autoload/fuzzyy/utils/selector.vim
@@ -279,11 +279,11 @@ export def FuzzySearchAsync(li: list<string>, pattern: string, limit: number, Cb
     return async_tid
 enddef
 
-def ReplaceCloseCb(Close_cb: func)
+export def ReplaceCloseCb(Close_cb: func)
     popup.SetPopupWinProp(menu_wid, 'close_cb', Close_cb)
 enddef
 
-def Close()
+export def Close()
     popup_close(menu_wid)
 enddef
 

--- a/plugin/fuzzyy.vim
+++ b/plugin/fuzzyy.vim
@@ -58,6 +58,7 @@ var windows: dict<any> = {
     grep: {},
     buffers: {},
     mru: {},
+    tags: {},
     highlights: {
         preview_ratio: 0.7,
     },
@@ -100,6 +101,7 @@ import autoload '../autoload/fuzzyy/buffers.vim'
 import autoload '../autoload/fuzzyy/highlights.vim'
 import autoload '../autoload/fuzzyy/cmdhistory.vim'
 import autoload '../autoload/fuzzyy/mru.vim'
+import autoload '../autoload/fuzzyy/tags.vim'
 import autoload '../autoload/fuzzyy/utils/selector.vim'
 
 command! -nargs=? FuzzyGrep grep.Start(extendnew(windows.grep, { search: <q-args> }))
@@ -117,6 +119,7 @@ command! -nargs=0 FuzzyCmdHistory cmdhistory.Start(windows.cmdhistory)
 command! -nargs=0 FuzzyMru mru.Start(windows.mru)
 command! -nargs=0 FuzzyMruCwd mru.Start(extendnew(windows.mru, { cwd: getcwd() }))
 command! -nargs=0 FuzzyMruRoot mru.Start(extendnew(windows.mru, { cwd: selector.GetRootDir() }))
+command! -nargs=0 FuzzyTags tags.Start(windows.tags)
 
 # Deprecated/renamed commands
 def Warn(msg: string)

--- a/plugin/fuzzyy.vim
+++ b/plugin/fuzzyy.vim
@@ -120,6 +120,7 @@ command! -nargs=0 FuzzyMru mru.Start(windows.mru)
 command! -nargs=0 FuzzyMruCwd mru.Start(extendnew(windows.mru, { cwd: getcwd() }))
 command! -nargs=0 FuzzyMruRoot mru.Start(extendnew(windows.mru, { cwd: selector.GetRootDir() }))
 command! -nargs=0 FuzzyTags tags.Start(windows.tags)
+command! -nargs=0 FuzzyTagsRoot tags.Start(extendnew(windows.tags, { cwd: selector.GetRootDir() }))
 
 # Deprecated/renamed commands
 def Warn(msg: string)


### PR DESCRIPTION
Tested with JS, Python, Ruby, C, and Markdown, should work fine with
other languages assuming tag address locates the correct line in file.

Only tested with Universal ctags, https://ctags.io/, may not support tag
files generated by other tag programs (can be addressed later if needed)

Supports CTRL+{s,t,v} keymaps to open in splits and tab, like FuzzyFiles etc.

Screenshot in use within fuzzy codebase... 
<img width="1265" alt="Screenshot 2025-01-23 at 07 53 04" src="https://github.com/user-attachments/assets/e84c059d-3758-4001-ad4a-9c88b8b295ef" />

Also tested with much larger codebases, including a mostly js codebase I work with regularly which has 190,863 tags.


