### PR TITLE
WIP: Add modeline fallback to detect preview filetype

### DIFF
--- a/autoload/fuzzyy/files.vim
+++ b/autoload/fuzzyy/files.vim
@@ -112,9 +112,17 @@ def Preview(wid: number, opts: dict<any>)
     if selector.IsBinary(path)
         noautocmd popup_settext(preview_wid, 'Cannot preview binary file')
     else
-        noautocmd popup_settext(preview_wid, readfile(path, '', 1000))
+        var content = readfile(path, '', 1000)
+        noautocmd popup_settext(preview_wid, content)
+        setwinvar(preview_wid, '&filetype', '')
         win_execute(preview_wid, 'silent! doautocmd filetypedetect BufNewFile ' .. path)
         noautocmd win_execute(preview_wid, 'silent! setlocal nospell nolist')
+        if empty(getwinvar(preview_wid, '&filetype')) || getwinvar(preview_wid, '&filetype') == 'conf'
+            var modelineft = selector.FTDetectModelines(content)
+            if !empty(modelineft)
+                win_execute(preview_wid, 'set filetype=' .. modelineft)
+            endif
+        endif
     endif
     win_execute(preview_wid, 'norm! gg')
 enddef

--- a/autoload/fuzzyy/grep.vim
+++ b/autoload/fuzzyy/grep.vim
@@ -327,9 +327,17 @@ def Preview(wid: number, opts: dict<any>)
 
     if path != last_path
         var preview_bufnr = winbufnr(preview_wid)
-        noautocmd popup_settext(preview_wid, readfile(path))
+        var content = readfile(path)
+        noautocmd popup_settext(preview_wid, content)
+        setwinvar(preview_wid, '&filetype', '')
         win_execute(preview_wid, 'silent! doautocmd filetypedetect BufNewFile ' .. path)
         noautocmd win_execute(preview_wid, 'silent! setlocal nospell nolist')
+        if empty(getwinvar(preview_wid, '&filetype')) || getwinvar(preview_wid, '&filetype') == 'conf'
+            var modelineft = selector.FTDetectModelines(content)
+            if !empty(modelineft)
+                win_execute(preview_wid, 'set filetype=' .. modelineft)
+            endif
+        endif
     endif
     if path != last_path || linenr != last_linenr
         win_execute(preview_wid, 'norm! ' .. linenr .. 'G')

--- a/autoload/fuzzyy/mru.vim
+++ b/autoload/fuzzyy/mru.vim
@@ -44,9 +44,17 @@ def Preview(wid: number, opts: dict<any>)
     if selector.IsBinary(path)
         noautocmd popup_settext(preview_wid, 'Cannot preview binary file')
     else
-        noautocmd popup_settext(preview_wid, readfile(path))
+        var content = readfile(path)
+        noautocmd popup_settext(preview_wid, content)
+        setwinvar(preview_wid, '&filetype', '')
         win_execute(preview_wid, 'silent! doautocmd filetypedetect BufNewFile ' .. path)
         noautocmd win_execute(preview_wid, 'silent! setlocal nospell nolist')
+        if empty(getwinvar(preview_wid, '&filetype')) || getwinvar(preview_wid, '&filetype') == 'conf'
+            var modelineft = selector.FTDetectModelines(content)
+            if !empty(modelineft)
+                win_execute(preview_wid, 'set filetype=' .. modelineft)
+            endif
+        endif
     endif
     win_execute(preview_wid, 'norm! gg')
 enddef

--- a/autoload/fuzzyy/tags.vim
+++ b/autoload/fuzzyy/tags.vim
@@ -131,9 +131,17 @@ def Preview(wid: number, opts: dict<any>)
         return
     endif
     var preview_bufnr = winbufnr(preview_wid)
-    noautocmd call popup_settext(preview_wid, readfile(path))
+    var content = readfile(path)
+    noautocmd popup_settext(preview_wid, content)
+    setwinvar(preview_wid, '&filetype', '')
     win_execute(preview_wid, 'silent! doautocmd filetypedetect BufNewFile ' .. path)
     noautocmd win_execute(preview_wid, 'silent! setlocal nospell nolist')
+    if empty(getwinvar(preview_wid, '&filetype')) || getwinvar(preview_wid, '&filetype') == 'conf'
+        var modelineft = selector.FTDetectModelines(content)
+        if !empty(modelineft)
+            win_execute(preview_wid, 'set filetype=' .. modelineft)
+        endif
+    endif
     for excmd in tagaddress->split(";")
         if trim(excmd) =~ '^\d\+$'
             win_execute(preview_wid, "silent! cursor(" .. excmd .. ", 1)")


### PR DESCRIPTION
Check modelines when filetype not detected using filetypedetect autocmd

Fuzzyy disables modelines for the preview window, which is sensible, you
don't want a modeline setting options and messing up the preview window.
But, this does mean that syntax highlighting is not enabled for some
files in the preview, but is enabled when opening the file for editing.

To address this, parse modelines if 'modeline' is on or securemodelines
plugin has been loaded (this is an old, but widely referenced plugin).

Note the check for either an empty &filetype or &filetype == 'conf'.
This is because 'conf' is used as the FALLBACK filetype in filetype.vim,
see :h :setfiletype and $VIMRUNTIME/filetype.vim, search for FALLBACK.

Note: Telescope.nvim also parse modelines, LeaderF just sets 'modeline'
