### PR TITLE
Add CTRL-Q keymap to send results to quickfix list

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ be used to scroll the preview window, but not the menu window.
   - \<CTRL-V> open selected file in vertical split
   - \<CTRL-T> open selected file in new tab page
 
+- FuzzyBuffers, FuzzyFiles, FuzzyGrep, FuzzyInBuffer, FuzzyMru
+  - \<CTRL-Q> send results to quickfix list
+
+Send results to quickfix list only includes results currently in the menu buffer,
+which effectively limits the results to a few hundred at most (this is probably
+what you want, sending thousands of results to the quickfix list is slow).
+
 ## Options
 
 ### g:fuzzyy_enable_mappings

--- a/autoload/fuzzyy/inbuffer.vim
+++ b/autoload/fuzzyy/inbuffer.vim
@@ -7,6 +7,7 @@ import autoload './utils/popup.vim'
 
 var raw_lines: list<string>
 var file_type: string
+var file_name: string
 
 def Select(wid: number, result: list<any>)
     var linenr = str2nr(split(result[0], ':')[0])
@@ -34,16 +35,45 @@ def Preview(wid: number, opts: dict<any>)
     win_execute(preview_wid, 'norm! zz')
 enddef
 
+def CloseQuickFix(wid: number, result: dict<any>)
+    var bufnr = winbufnr(wid)
+    var lines: list<any>
+    lines = reverse(getbufline(bufnr, 1, "$"))
+    filter(lines, (_, val) => !empty(val))
+    map(lines, (_, val) => {
+        var [line, text] = split(val, '│')
+        var dict = {
+            filename: file_name,
+            lnum: str2nr(line),
+            col: 1,
+            text: text }
+        return dict
+    })
+    setqflist(lines)
+    exe 'copen'
+enddef
+
+def SetQuickFixClose()
+    selector.ReplaceCloseCb(function('CloseQuickFix'))
+    selector.Close()
+enddef
+
+var split_edit_callbacks = {
+    "\<c-q>": function('SetQuickFixClose'),
+}
+
 export def Start(opts: dict<any> = {})
     raw_lines = getline(1, '$')
     file_type = &filetype
+    file_name = expand('%')
     var max_line_len = len(string(line('$')))
     var lines = reduce(raw_lines,
        (a, v) => add(a, printf(' %' .. max_line_len .. 'd │ %s', len(a) + 1,  v)), [])
 
     var winds = selector.Start(lines, extend(opts, {
         select_cb: function('Select'),
-        preview_cb: function('Preview')
+        preview_cb: function('Preview'),
+        key_callbacks: split_edit_callbacks,
     }))
 
     if len(get(opts, 'search', '')) > 0

--- a/autoload/fuzzyy/utils/selector.vim
+++ b/autoload/fuzzyy/utils/selector.vim
@@ -435,6 +435,31 @@ def CloseSplit(wid: number, result: dict<any>)
     endif
 enddef
 
+def CloseQuickFix(wid: number, result: dict<any>)
+    var bufnr = winbufnr(wid)
+    var lines: list<any>
+    lines = reverse(getbufline(bufnr, 1, "$"))
+    filter(lines, (_, val) => !empty(val))
+    map(lines, (_, val) => {
+        var [path, line, col] = split(val .. ':1:1', ':')[0 : 2]
+        var text = split(val, ':' .. line .. ':' .. col .. ':')[-1]
+        if enable_devicons
+            if path == text
+                text = strcharpart(path, devicon_char_width + 1)
+            endif
+            path = strcharpart(path, devicon_char_width + 1)
+        endif
+        var dict = {
+            filename: path,
+            lnum: str2nr(line),
+            col: str2nr(col),
+            text: text }
+        return dict
+    })
+    setqflist(lines)
+    exe 'copen'
+enddef
+
 def SetVSplitClose()
     ReplaceCloseCb(function('CloseVSplit'))
     Close()
@@ -450,10 +475,16 @@ def SetTabClose()
     Close()
 enddef
 
+def SetQuickFixClose()
+    ReplaceCloseCb(function('CloseQuickFix'))
+    Close()
+enddef
+
 export var split_edit_callbacks = {
     "\<c-v>": function('SetVSplitClose'),
     "\<c-s>": function('SetSplitClose'),
     "\<c-t>": function('SetTabClose'),
+    "\<c-q>": function('SetQuickFixClose'),
 }
 
 export def MoveToUsableWindow(buf: any = null)


### PR DESCRIPTION
Works more or less the same as Telescope.nvim, but no option yet to
select multiple results, just sends all visible results to quickfix.

LeaderF has a similar feature, but with a different mapping, fzf.vim
also has a similar feature, but you need to select multiple results
first (Telescope also allows this, but by default sends all to qf).
