### PR TITLE
Allow devicons to be customised (use other nerdfont compatible plugins for glyphs and colors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,21 @@ let g:fuzzyy_devicons_glyph_func = 'nerdfont#find'
 ```
 The function should take a single string argument and return a single glyph.
 
+### g:fuzzyy_devicons_color_func
+Specify a custom function for colorizing devicon glyphs. By default Fuzzyy does
+this with an internal function using a small set of common file name patterns
+and colors, but you may want more extensive support for file name patterns not
+recognised by Fuzzyy and to apply the same colors to Fuzzyy as other plugins.
+Default ''
+```vim
+let g: fuzzyy_devicons_color_func = ''
+```
+Example usage
+```vim
+let g: fuzzyy_devicons_color_func = 'glyph_palette#apply'
+```
+The function should take no arguments and use matchadd() to add highlighting.
+
 ### g:fuzzyy_keymaps
 Change navigation keymaps. The following are the defaults
 ```vim

--- a/README.md
+++ b/README.md
@@ -255,6 +255,20 @@ let g:fuzzyy_ripgrep_options = [
 This option can also be set specifically for FuzzyFiles and/or FuzzyGrep using
 `g:fuzzyy_files_ripgrep_options` and `g:fuzzyy_grep_ripgrep_options`
 
+### g:fuzzyy_devicons_glyph_func
+Specify a custom function for obtaining devicon glyphs from file names or paths.
+By default Fuzzyy integrates with vim-devicons to obtain glyphs and measure byte
+widths. You can use this option to obtain devicon glyphs from another nerdfont
+compatible plugin, or your own custom function. Default ''
+```vim
+let g:fuzzyy_devicons_glyph_func = ''
+```
+Example usage
+```vim
+let g:fuzzyy_devicons_glyph_func = 'nerdfont#find'
+```
+The function should take a single string argument and return a single glyph.
+
 ### g:fuzzyy_keymaps
 Change navigation keymaps. The following are the defaults
 ```vim

--- a/autoload/fuzzyy/utils/devicons.vim
+++ b/autoload/fuzzyy/utils/devicons.vim
@@ -7,6 +7,8 @@ var devicon_byte_width = 0
 var glyph_func = exists('g:fuzzyy_devicons_glyph_func') ? g:fuzzyy_devicons_glyph_func : (
     exists('g:WebDevIconsGetFileTypeSymbol') ? 'g:WebDevIconsGetFileTypeSymbol' : ''
 )
+var color_func = exists('g:fuzzyy_devicons_color_func') ? g:fuzzyy_devicons_color_func : ''
+
 export var enabled = exists('g:fuzzyy_devicons') && !empty(glyph_func) ?
     g:fuzzyy_devicons : !empty(glyph_func)
 
@@ -75,6 +77,10 @@ var devicons_color_table = {
 var others_color = 'fuzzyy_yellow'
 
 export def AddColor(wid: number)
+    if !empty(color_func)
+        win_execute(wid, color_func .. '()')
+        return
+    endif
     for ft in keys(devicons_color_table)
         var icon = GetDevicon(ft)
         var charnr = char2nr(icon)

--- a/autoload/fuzzyy/utils/devicons.vim
+++ b/autoload/fuzzyy/utils/devicons.vim
@@ -2,15 +2,24 @@ vim9script
 
 var devicon_char_width = 0
 var devicon_byte_width = 0
-if exists('g:WebDevIconsGetFileTypeSymbol')
-    var test_devicon = g:WebDevIconsGetFileTypeSymbol('a.lua')
+
+# Options
+var glyph_func = exists('g:fuzzyy_devicons_glyph_func') ? g:fuzzyy_devicons_glyph_func : (
+    exists('g:WebDevIconsGetFileTypeSymbol') ? 'g:WebDevIconsGetFileTypeSymbol' : ''
+)
+export var enabled = exists('g:fuzzyy_devicons') && !empty(glyph_func) ?
+    g:fuzzyy_devicons : !empty(glyph_func)
+
+export var GetDevicon: func
+if !empty(glyph_func)
+    GetDevicon = function(glyph_func)
+endif
+
+if enabled
+    var test_devicon = GetDevicon('a.lua')
     devicon_char_width = strcharlen(test_devicon)
     devicon_byte_width = strlen(test_devicon)
 endif
-
-export var enabled = exists('g:fuzzyy_devicons')
-    && exists('g:WebDevIconsGetFileTypeSymbol') ?
-    g:fuzzyy_devicons : exists('g:WebDevIconsGetFileTypeSymbol')
 
 def SetHl()
     hi fuzzyy_yellow ctermfg=215 guifg=#f5c06f
@@ -67,7 +76,7 @@ var others_color = 'fuzzyy_yellow'
 
 export def AddColor(wid: number)
     for ft in keys(devicons_color_table)
-        var icon = g:WebDevIconsGetFileTypeSymbol(ft)
+        var icon = GetDevicon(ft)
         var charnr = char2nr(icon)
         var charhex = printf('%x', charnr)
         try
@@ -87,10 +96,10 @@ enddef
 export def AddDevicons(li: list<string>): list<string>
     if !empty(li) && stridx(li[0], ':') != -1
         map(li, (_, val) => {
-            return g:WebDevIconsGetFileTypeSymbol(split(val, ':')[0]) .. ' ' .. val
+            return GetDevicon(split(val, ':')[0]) .. ' ' .. val
         })
     else
-        map(li, 'g:WebDevIconsGetFileTypeSymbol(v:val) .. " " .. v:val')
+        map(li, 'GetDevicon(v:val) .. " " .. v:val')
     endif
     return li
 enddef

--- a/doc/fuzzyy.txt
+++ b/doc/fuzzyy.txt
@@ -25,11 +25,13 @@ CONTENTS                                                       *fuzzyy-contents*
     1.7.9. g:fuzzyy_exclude_file..................|fuzzyy-g:fuzzyy_exclude_file|
     1.7.10. g:fuzzyy_exclude_dir...................|fuzzyy-g:fuzzyy_exclude_dir|
     1.7.11. g:fuzzyy_ripgrep_options...........|fuzzyy-g:fuzzyy_ripgrep_options|
-    1.7.12. g:fuzzyy_keymaps...........................|fuzzyy-g:fuzzyy_keymaps|
-    1.7.13. g:fuzzyy_buffers_exclude...........|fuzzyy-g:fuzzyy_buffers_exclude|
-    1.7.14. g:fuzzyy_buffers_keymap.............|fuzzyy-g:fuzzyy_buffers_keymap|
-    1.7.15. g:fuzzyy_window_layout...............|fuzzyy-g:fuzzyy_window_layout|
-    1.7.16. g:fuzzyy_async_step.....................|fuzzyy-g:fuzzyy_async_step|
+    1.7.12. g:fuzzyy_devicons_glyph_func...|fuzzyy-g:fuzzyy_devicons_glyph_func|
+    1.7.13. g:fuzzyy_devicons_color_func...|fuzzyy-g:fuzzyy_devicons_color_func|
+    1.7.14. g:fuzzyy_keymaps...........................|fuzzyy-g:fuzzyy_keymaps|
+    1.7.15. g:fuzzyy_buffers_exclude...........|fuzzyy-g:fuzzyy_buffers_exclude|
+    1.7.16. g:fuzzyy_buffers_keymap.............|fuzzyy-g:fuzzyy_buffers_keymap|
+    1.7.17. g:fuzzyy_window_layout...............|fuzzyy-g:fuzzyy_window_layout|
+    1.7.18. g:fuzzyy_async_step.....................|fuzzyy-g:fuzzyy_async_step|
   1.8. Syntax highlighting..........................|fuzzyy-syntax_highlighting|
 
 ==============================================================================
@@ -312,6 +314,41 @@ Example usage
 
 This option can also be set specifically for FuzzyFiles and/or FuzzyGrep using
 `g:fuzzyy_files_ripgrep_options` and `g:fuzzyy_grep_ripgrep_options`
+
+G:FUZZYY_DEVICONS_GLYPH_FUNC               *fuzzyy-g:fuzzyy_devicons_glyph_func*
+
+Specify a custom function for obtaining devicon glyphs from file names or paths.
+By default Fuzzyy integrates with vim-devicons to obtain glyphs and measure byte
+widths. You can use this option to obtain devicon glyphs from another nerdfont
+compatible plugin, or your own custom function. Default ''
+>
+  let g:fuzzyy_devicons_glyph_func = ''
+<
+
+Example usage
+>
+  let g:fuzzyy_devicons_glyph_func = 'nerdfont#find'
+<
+
+The function should take a single string argument and return a single glyph.
+
+G:FUZZYY_DEVICONS_COLOR_FUNC               *fuzzyy-g:fuzzyy_devicons_color_func*
+
+Specify a custom function for colorizing devicon glyphs. By default Fuzzyy does
+this with an internal function using a small set of common file name patterns
+and colors, but you may want more extensive support for file name patterns not
+recognised by Fuzzyy and to apply the same colors to Fuzzyy as other plugins.
+Default ''
+>
+  let g: fuzzyy_devicons_color_func = ''
+<
+
+Example usage
+>
+  let g: fuzzyy_devicons_color_func = 'glyph_palette#apply'
+<
+
+The function should take no arguments and use matchadd() to add highlighting.
 
 G:FUZZYY_KEYMAPS                                       *fuzzyy-g:fuzzyy_keymaps*
 


### PR DESCRIPTION
This allows other plugins or custom functions to be used for devicons,
e.g. for vim-nerdfont `let g:fuzzyy_devicon_func = 'nerdfont#find'`

Note: vim-nerdfont does not follow the typical pattern for vim plugins
to set a "g:plugin_loaded" variable, and only uses autoloaded functions,
so there is no easy way for fuzzyy to check if it has been loaded.

Technical note: Fuzzyy measures the byte width for a single glyph and
assumes all glyphs returned by the devicon function are the same width
(this is almost certainly true, they should all be in the same Unicode
private use area so should use the same number of bytes in utf8, but
if you run into some weirdness with a custom function, could be this)
