### PR TITLE
Disable utf-8 features when &encoding not utf-8

### DIFF
--- a/autoload/fuzzyy/utils/devicons.vim
+++ b/autoload/fuzzyy/utils/devicons.vim
@@ -13,6 +13,10 @@ var color_func = exists('g:fuzzyy_devicons_color_func') ? g:fuzzyy_devicons_colo
 
 var enabled = exists('g:fuzzyy_devicons') && !empty(glyph_func) ? g:fuzzyy_devicons : !empty(glyph_func)
 
+if &encoding != 'utf-8'
+    enabled = false
+endif
+
 export def Enabled(): bool
     return enabled
 enddef

--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -331,6 +331,10 @@ def CreatePopup(args: dict<any>): number
        borderhighlight: ['fuzzyyBorder'],
        highlight: 'fuzzyyNormal', }
 
+    if &encoding != 'utf-8'
+        remove(opts, 'borderchars')
+    endif
+
     if has_key(args, 'enable_border') && !args.enable_border
         remove(opts, 'border')
     endif


### PR DESCRIPTION
Some features require utf-8, i.e. devicons and custom borderchars. 
Fuzzyy starts with a warning when the encoding is not utf-8, but even
better to show the warning and disable the features that require utf-8.

**before**
<img width="1440" alt="Screenshot 2025-03-30 at 10 16 51" src="https://github.com/user-attachments/assets/30455d21-8c6e-4c0c-84cf-f2b9fac53609" />

**after**
<img width="1440" alt="Screenshot 2025-03-30 at 10 16 20" src="https://github.com/user-attachments/assets/a1dc873f-2f71-402b-9b94-16df20842635" />

