### PR TITLE
Add vim-nerdfont, vim-glyph-palette, and vim-nerdtree-syntax-highlight compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ programs to handle complex tasks.
 
 - [ripgrep](https://github.com/BurntSushi/ripgrep) - used for FuzzyGrep and
   FuzzyFiles if installed, faster than the defaults and respects gitignore
-- [vim-devicons](https://github.com/ryanoasis/vim-devicons) - used to show
-  [devicons](https://devicon.dev/) when listing files if installed
 
 ### Optional dependencies
 
@@ -35,6 +33,17 @@ programs to handle complex tasks.
   repo and no alternative dependency installed
 - [ctags](https://ctags.io) - used to generate tags for FuzzyTags (Universal
   Ctags implementation is required)
+  
+### Compatibile plugins
+- [vim-devicons](https://github.com/ryanoasis/vim-devicons) - used to show
+  [devicons](https://devicon.dev/) when listing files if installed
+- [vim-nerdfont](https://github.com/lambdalisue/vim-nerdfont) - alternative
+  plugin to show devicons, used if installed and vim-devicons not installed
+- [vim-glyph-palette](https://github.com/lambdalisue/vim-glyph-palette) - used
+  to colorize devicons if installed, instead of Fuzzyy's own color mappings
+- [vim-nerdtree-syntax-highlight](https://github.com/tiagofumo/vim-nerdtree-syntax-highlight) - 
+  used to colorize devicons if installed, and [vim-nerdtree](https://github.com/preservim/nerdtree)
+  installed
 
 ## Install
 

--- a/autoload/fuzzyy/utils/colors.vim
+++ b/autoload/fuzzyy/utils/colors.vim
@@ -1,9 +1,49 @@
 vim9script
 
-# Exports one function, to get a terminal color number from a color name
+# Color table stored outside of devicons script to allow it to be modified
+# before loading devicons, which creates highlight groups using these colors
+export var devicons_color_table = {
+    '__default__': 'lightblue4',
+    '*.lua': 'lightblue3',
+    '*.js': 'sandybrown',
+    '*.ts': 'sandybrown',
+    '*.go': 'lightblue3',
+    '*.c': 'lightblue3',
+    '*.cpp': 'teal',
+    '*.java': 'darksalmon',
+    '*.php': 'mediumorchid',
+    '*.rb': 'darksalmon',
+    '*.sh': 'teal',
+    '*.html': 'sandybrown',
+    '*.css': 'lightblue3',
+    '*.scss': 'lightblue3',
+    '*.less': 'lightblue3',
+    '*.json': 'indianred',
+    '*.toml': 'grey',
+    '*.sql': 'teal',
+    '*.md': 'sandybrown',
+    '*.tex': 'lightblue3',
+    '*.vue': 'darkseagreen',
+    '*.swift': 'darksalmon',
+    '*.dart': 'lightblue3',
+    '*.elm': 'lightblue3',
+    '*.vim': 'darkseagreen',
+    '*.png': 'teal',
+    '*.py': 'goldenrod',
+    'LICENSE': 'mediumorchid',
+}
+if exists('g:fuzzyy_devicons_color_table') && type(g:fuzzyy_devicons_color_table) == v:t_dict
+    extend(devicons_color_table, g:fuzzyy_devicons_color_table)
+endif
 
+
+# Code to get a 256 color number from a color name or hex value in the
+# color table, used by devicons script when creating hightlight groups
+#
 # Copied from https://github.com/tiagofumo/vim-nerdtree-syntax-highlight,
 # which copied from https://github.com/chriskempson/vim-tomorrow-theme.
+# Exports one function, to get a terminal color number from a color name
+#
 # Removed support for fewer than 256 colors, and updated for vim9script
 # Also updated to use American rather than British English (I personally
 # write in British English, but Fuzzyy generally uses American English)

--- a/autoload/fuzzyy/utils/devicons.vim
+++ b/autoload/fuzzyy/utils/devicons.vim
@@ -31,39 +31,8 @@ if enabled
     devicon_byte_width = strlen(test_devicon)
 endif
 
-var devicons_color_table = {
-    '__default__': 'lightblue4',
-    '*.lua': 'lightblue3',
-    '*.js': 'sandybrown',
-    '*.ts': 'sandybrown',
-    '*.go': 'lightblue3',
-    '*.c': 'lightblue3',
-    '*.cpp': 'teal',
-    '*.java': 'darksalmon',
-    '*.php': 'mediumorchid',
-    '*.rb': 'darksalmon',
-    '*.sh': 'teal',
-    '*.html': 'sandybrown',
-    '*.css': 'lightblue3',
-    '*.scss': 'lightblue3',
-    '*.less': 'lightblue3',
-    '*.json': 'indianred',
-    '*.toml': 'grey',
-    '*.sql': 'teal',
-    '*.md': 'sandybrown',
-    '*.tex': 'lightblue3',
-    '*.vue': 'darkseagreen',
-    '*.swift': 'darksalmon',
-    '*.dart': 'lightblue3',
-    '*.elm': 'lightblue3',
-    '*.vim': 'darkseagreen',
-    '*.png': 'teal',
-    '*.py': 'goldenrod',
-    'LICENSE': 'mediumorchid',
-}
-if exists('g:fuzzyy_devicons_color_table') && type(g:fuzzyy_devicons_color_table) == v:t_dict
-    extend(devicons_color_table, g:fuzzyy_devicons_color_table)
-endif
+# Allows the colors to be changed before loading devicons, see compat/fuzzyy.vim
+var devicons_color_table = colors.devicons_color_table
 
 def SetHl()
     for val in uniq(values(devicons_color_table))

--- a/autoload/fuzzyy/utils/devicons.vim
+++ b/autoload/fuzzyy/utils/devicons.vim
@@ -6,9 +6,8 @@ var devicon_char_width = 0
 var devicon_byte_width = 0
 
 # Options
-var glyph_func = exists('g:fuzzyy_devicons_glyph_func') ? g:fuzzyy_devicons_glyph_func : (
-    exists('g:WebDevIconsGetFileTypeSymbol') ? 'g:WebDevIconsGetFileTypeSymbol' : ''
-)
+var glyph_func = exists('g:fuzzyy_devicons_glyph_func') ? g:fuzzyy_devicons_glyph_func : ''
+
 var color_func = exists('g:fuzzyy_devicons_color_func') ? g:fuzzyy_devicons_color_func : ''
 
 var enabled = exists('g:fuzzyy_devicons') && !empty(glyph_func) ? g:fuzzyy_devicons : !empty(glyph_func)

--- a/compat/fuzzyy.vim
+++ b/compat/fuzzyy.vim
@@ -6,6 +6,10 @@ if exists("g:loaded_fuzzyy_compat")
 endif
 g:loaded_fuzzyy_compat = 1
 
+if exists('g:loaded_nerdfont') && !exists('g:loaded_webdevicons') && !exists('g:fuzzyy_devicons_glyph_func')
+    g:fuzzyy_devicons_glyph_func = 'nerdfont#find'
+endif
+
 if exists('g:loaded_glyph_palette') && !exists('g:fuzzyy_devicons_color_func')
     g:fuzzyy_devicons_color_func = 'glyph_palette#apply'
 endif

--- a/compat/fuzzyy.vim
+++ b/compat/fuzzyy.vim
@@ -6,7 +6,11 @@ if exists("g:loaded_fuzzyy_compat")
 endif
 g:loaded_fuzzyy_compat = 1
 
-if exists('g:loaded_nerdfont') && !exists('g:loaded_webdevicons') && !exists('g:fuzzyy_devicons_glyph_func')
+if exists('g:loaded_webdevicons') && !exists('g:fuzzyy_devicons_glyph_func')
+    g:fuzzyy_devicons_glyph_func = 'g:WebDevIconsGetFileTypeSymbol'
+endif
+
+if exists('g:loaded_nerdfont') && !exists('g:fuzzyy_devicons_glyph_func')
     g:fuzzyy_devicons_glyph_func = 'nerdfont#find'
 endif
 

--- a/compat/fuzzyy.vim
+++ b/compat/fuzzyy.vim
@@ -6,7 +6,12 @@ if exists("g:loaded_fuzzyy_compat")
 endif
 g:loaded_fuzzyy_compat = 1
 
-if exists('g:loaded_nerd_tree') && findfile('after/syntax/nerdtree.vim', &rtp) =~ 'nerdtree-syntax-highlight'
+if exists('g:loaded_glyph_palette') && !exists('g:fuzzyy_devicons_color_func')
+    g:fuzzyy_devicons_color_func = 'glyph_palette#apply'
+endif
+
+if exists('g:loaded_nerd_tree') && !exists('g:fuzzyy_devicons_color_func') &&
+        findfile('after/syntax/nerdtree.vim', &rtp) =~ 'nerdtree-syntax-highlight'
     import '../autoload/fuzzyy/utils/colors.vim'
     runtime! after/syntax/nerdtree.vim
     map(colors.devicons_color_table, (key, val) => {

--- a/compat/fuzzyy.vim
+++ b/compat/fuzzyy.vim
@@ -1,0 +1,22 @@
+vim9script
+
+# Compatibility hacks, loaded from VimEnter autocmd in plugin/fuzzyy.vim
+if exists("g:loaded_fuzzyy_compat")
+  finish
+endif
+g:loaded_fuzzyy_compat = 1
+
+if exists('g:loaded_nerd_tree') && findfile('after/syntax/nerdtree.vim', &rtp) =~ 'nerdtree-syntax-highlight'
+    import '../autoload/fuzzyy/utils/colors.vim'
+    runtime! after/syntax/nerdtree.vim
+    map(colors.devicons_color_table, (key, val) => {
+        var ext = fnamemodify(key, ':e')
+        if !empty(ext) && hlexists('nerdtreeFileExtensionIcon_' .. tolower(ext))
+            return hlget('nerdtreeFileExtensionIcon_' .. tolower(ext))[0]['guifg']
+        elseif hlexists('nerdtreeExactMatchIcon_' .. tolower(key))
+            return hlget('nerdtreeExactMatchIcon_' .. tolower(key))[0]['guifg']
+        else
+            return val
+        endif
+    })->filter((key, val) => key != '__default__')
+endif

--- a/doc/fuzzyy.txt
+++ b/doc/fuzzyy.txt
@@ -9,6 +9,7 @@ CONTENTS                                                       *fuzzyy-contents*
   1.2. Requirements........................................|fuzzyy-requirements|
     1.2.1. Suggested dependencies................|fuzzyy-suggested_dependencies|
     1.2.2. Optional dependencies..................|fuzzyy-optional_dependencies|
+    1.2.3. Compatibile plugins......................|fuzzyy-compatibile_plugins|
   1.3. Install..................................................|fuzzyy-install|
   1.4. Commands................................................|fuzzyy-commands|
   1.5. Mappings................................................|fuzzyy-mappings|
@@ -63,8 +64,6 @@ SUGGESTED DEPENDENCIES                           *fuzzyy-suggested_dependencies*
 
 * ripgrep (https://github.com/BurntSushi/ripgrep) - used for FuzzyGrep and
   FuzzyFiles if installed, faster than the defaults and respects gitignore
-* vim-devicons (https://github.com/ryanoasis/vim-devicons) - used to show
-  devicons (https://devicon.dev/) when listing files if installed
 
 OPTIONAL DEPENDENCIES                             *fuzzyy-optional_dependencies*
 
@@ -76,6 +75,18 @@ OPTIONAL DEPENDENCIES                             *fuzzyy-optional_dependencies*
   repo and no alternative dependency installed
 * ctags (https://ctags.io) - used to generate tags for FuzzyTags (Universal
   Ctags implementation is required)
+
+COMPATIBILE PLUGINS                                 *fuzzyy-compatibile_plugins*
+
+* vim-devicons (https://github.com/ryanoasis/vim-devicons) - used to show
+  devicons (https://devicon.dev/) when listing files if installed
+* vim-nerdfont (https://github.com/lambdalisue/vim-nerdfont) - alternative
+  plugin to show devicons, used if installed and vim-devicons not installed
+* vim-glyph-palette (https://github.com/lambdalisue/vim-glyph-palette) - used
+  to colorize devicons if installed, instead of Fuzzyy's own color mappings
+* vim-nerdtree-syntax-highlight (https://github.com/tiagofumo/vim-nerdtree-syntax-highlight) -
+  used to colorize devicons if installed, and vim-nerdtree (https://github.com/preservim/nerdtree)
+  installed
 
 ------------------------------------------------------------------------------
 INSTALL                                                         *fuzzyy-install*

--- a/plugin/fuzzyy.vim
+++ b/plugin/fuzzyy.vim
@@ -162,3 +162,9 @@ if g:fuzzyy_enable_mappings
         endif
     endfor
 endif
+
+# Load compatibility hacks on VimEnter, after other plugins are loaded
+augroup fuzzyyCompat
+  au!
+  autocmd VimEnter * runtime! compat/fuzzyy.vim
+augroup END


### PR DESCRIPTION
This adds a new compat script loaded on VimEnter where compatibilities with other plugins can be defined, moves the existing vim-devicons compatibility code to that compat script, and adds similar code for vim-nerdfont, vim-glyph-palette, and vim-nerdtree-syntax-highlight. 

vim-devicons remains the first priority for the devicons glyph function, vim-glyph-palette and vim-nerdtree-syntax-highlight will only be used automatically if the user has not already set g:fuzzyy_devicons_color_func. For an existing user of nerdtree, vim-nerdtree-syntax-highlight, and fuzzyy, they will now magically get the same colors in Fuzzyy as in  NERDTree (for all devicons known to Fuzzyy)

**before**
<img width="1432" alt="Screenshot 2025-04-04 at 08 50 04" src="https://github.com/user-attachments/assets/747ad646-78e5-4f32-abfe-8a6b069c5da6" />

**after** (with vim-nerdtree-syntax-highlight) 
<img width="1431" alt="Screenshot 2025-04-04 at 08 50 47" src="https://github.com/user-attachments/assets/87ec5245-1395-4858-b30d-9bb679a54430" />

**after** (with vim-glyph-palette)
<img width="1429" alt="Screenshot 2025-04-04 at 08 51 26" src="https://github.com/user-attachments/assets/a78725a9-dfd2-49d0-b7ff-f133f33415ed" />

**after** (with vim-nerdfont, and without vim-devivons)
<img width="1434" alt="Screenshot 2025-04-04 at 08 55 00" src="https://github.com/user-attachments/assets/cd61c3ce-8bab-49d5-8005-0a5668e4ca53" />

