### PR TITLE
Use colorscheme's Cursor hl group for cursor

### DIFF
--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -67,7 +67,7 @@ def HideCursor()
             || hlcursor_resolved->has_key('ctermfg')
         hlset([extend(hlcursor_resolved, {name: 'fuzzyyPopup_cursor'})])
     else
-        hlset([fallback_cursor])
+        hlset([extend(hlcursor_resolved, fallback_cursor)])
     endif
     hlset([{name: 'Cursor', cleared: true}])
 enddef

--- a/doc/fuzzyy.txt
+++ b/doc/fuzzyy.txt
@@ -498,11 +498,17 @@ It is also possible to modify the colors used for highlighting. The defaults are
 shown below, you can change them in your vimrc. See :help :highlight if you are
 unfamiliar with Vim highlighting
 >
-  highlight default link fuzzyyCursor Search
+  highlight default link fuzzyyCursor Cursor
   highlight default link fuzzyyNormal Normal
   highlight default link fuzzyyBorder Normal
   highlight default link fuzzyyMatching Special
   highlight default link fuzzyyPreviewMatch CurSearch
 <
+
+Note: when the popup is open, fuzzyy will technically hide the terminal cursor
+and clear the Cursor highlight group. This is to work around limitations in how
+|popupwin| operates. Therefore, to work around this, when the popup is open the
+Cursor highlight group's resolved properties are copied to an internal
+highlight group and used only if fuzzyyCursor is linked to Cursor.
 
  vim:tw=78:ts=2:ft=help:

--- a/plugin/fuzzyy.vim
+++ b/plugin/fuzzyy.vim
@@ -88,7 +88,7 @@ if exists('g:fuzzyy_window_layout') && type(g:fuzzyy_window_layout) == v:t_dict
     endfor
 endif
 
-highlight default link fuzzyyCursor Search
+highlight default link fuzzyyCursor Cursor
 highlight default link fuzzyyNormal Normal
 highlight default link fuzzyyBorder Normal
 highlight default link fuzzyyMatching Special


### PR DESCRIPTION
Due to limitations in how popupwin operates, attempting to use the Cursor highlight group would not be possible as it is necessary to hide it during popups.

This works around that by copying Cursor's resolved properties to an internal highlight group `fuzzyPopup_cursor` that will be used only if `fuzzyCursor` is not linked to `Cursor`.

---

It struck me as odd to not use the colour scheme's Cursor highlight group, until I delved into the details of what was happening. I hope this is decent workaround that can be used :)