### PR TITLE
Add user autocmds to aid plugin compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,24 @@ if you notice a lack of responsiveness on low spec machines
 let g:fuzzyy_async_step = 10000
 ```
 
+## User autocommands
+
+Fuzzyy adds two `User` autocommands which you can use to run custom commands
+when Fuzzyy is opened and closed. This can be helpful to aid compatibility with
+other plugins, e.g. [vim-lsp](https://github.com/prabirshrestha/vim-lsp)
+
+By default vim-lsp will automatically start configured language servers when the
+filetype of a buffer changes. To avoid starting language servers unnecessarily
+when you preview a file in Fuzzyy you can disable vim-lsp while Fuzzyy is open:
+
+```vim
+augroup LspFuzzyy
+  autocmd!
+  autocmd User FuzzyyOpened call lsp#disable()
+  autocmd User FuzzyyClosed call lsp#enable()
+augroup END
+```
+
 ## Syntax highlighting
 
 It is also possible to modify the colors used for highlighting. The defaults are

--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -162,11 +162,10 @@ def GeneralPopupCallback(wid: number, select: any)
         opt.cursor_item = popup_wins[wid].cursor_item
         popup_wins[wid].close_cb(wid, opt)
     endif
-    if exists('#User#PopupClosed')
-        doautocmd User PopupClosed
-    endif
 
     popup_wins = {}
+
+    silent doautocmd <nomodeline> User FuzzyyClosed
 enddef
 
 # Handle situation when Text under cursor in menu window is changed
@@ -776,6 +775,8 @@ export def PopupSelection(opts: dict<any>): dict<any>
     popup_wins[wins.prompt].partids = wins
 
     HideCursor()
+
+    silent doautocmd <nomodeline> User FuzzyyOpened
 
     return wins
 enddef

--- a/doc/fuzzyy.txt
+++ b/doc/fuzzyy.txt
@@ -35,7 +35,8 @@ CONTENTS                                                       *fuzzyy-contents*
     1.7.18. g:fuzzyy_buffers_keymap.............|fuzzyy-g:fuzzyy_buffers_keymap|
     1.7.19. g:fuzzyy_window_layout...............|fuzzyy-g:fuzzyy_window_layout|
     1.7.20. g:fuzzyy_async_step.....................|fuzzyy-g:fuzzyy_async_step|
-  1.8. Syntax highlighting..........................|fuzzyy-syntax_highlighting|
+  1.8. User autocommands..............................|fuzzyy-user_autocommands|
+  1.9. Syntax highlighting..........................|fuzzyy-syntax_highlighting|
 
 ==============================================================================
 FUZZYY                                                           *fuzzyy-fuzzyy*
@@ -489,6 +490,24 @@ should work well for most developer workstations, but you might want to reduce
 if you notice a lack of responsiveness on low spec machines
 >
   let g:fuzzyy_async_step = 10000
+<
+
+------------------------------------------------------------------------------
+USER AUTOCOMMANDS                                     *fuzzyy-user_autocommands*
+
+Fuzzyy adds two `User` autocommands which you can use to run custom commands
+when Fuzzyy is opened and closed. This can be helpful to aid compatibility with
+other plugins, e.g. vim-lsp (https://github.com/prabirshrestha/vim-lsp)
+
+By default vim-lsp will automatically start configured language servers when the
+filetype of a buffer changes. To avoid starting language servers unnecessarily
+when you preview a file in Fuzzyy you can disable vim-lsp while Fuzzyy is open:
+>
+  augroup LspFuzzyy
+    autocmd!
+    autocmd User FuzzyyOpened call lsp#disable()
+    autocmd User FuzzyyClosed call lsp#enable()
+  augroup END
 <
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
When using vim-lsp, language servers are started automatically when the
filetype is changed, which happens within the Fuzzyy preview window.

Adding user autocmds that are triggered when Fuzzyy opens and closes
allows vim-lsp to be disabled temporarily while Fuzzyy is open, e.g.

    augroup LspFuzzyy
      autocmd!
      autocmd User FuzzyyOpened call lsp#disable()
      autocmd User FuzzyyClosed call lsp#enable()
    augroup END

It turns out that setting `let g:lsp_untitled_buffer_enabled = 0`
achieves the same thing, but that is not exactly obvious from the
variable name (only looking at the code is it clear what this does).

Having said that, adding these user autocmds seems a good thing to allow
for compatibility with other plugins in general, not just for vim-lsp.

Note: this change replaces the PopupClosed user autocmd with FuzzyyClosed

TODO: add vim-lsp to automatic compat hacks and document user autocmds
