### PR TITLE
Add FuzzyyPrevious command, reload previous search

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ git clone https://github.com/Donaldttt/fuzzyy ~/.vim/pack/Donaldttt/start/fuzzyy
 | FuzzyTags             | search tags in tagfiles(), see `:h tags`
 | FuzzyTagsRoot         | search tags in the project/vcs root directory
 | FuzzyGitFiles         | search files in output from `git ls-files`
+| FuzzyPrevious         | reloads the previous selector and search string
 | FuzzyHelps            | deprecated alias for FuzzyHelp, will be removed
 | FuzzyMRUFiles         | deprecated alias for FuzzyMru, will be removed
 
@@ -105,6 +106,7 @@ nnoremap <silent> <leader>fg :FuzzyGrep<CR>
 nnoremap <silent> <leader>fh :FuzzyHelp<CR>
 nnoremap <silent> <leader>fi :FuzzyInBuffer<CR>
 nnoremap <silent> <leader>fm :FuzzyMru<CR>
+nnoremap <silent> <leader>fp :FuzzyPrevious<CR>
 nnoremap <silent> <leader>fr :FuzzyMruCwd<CR>
 ```
 

--- a/autoload/fuzzyy/utils/launcher.vim
+++ b/autoload/fuzzyy/utils/launcher.vim
@@ -1,0 +1,57 @@
+vim9script
+
+import autoload './popup.vim'
+
+export def Start(selector: string, opts: dict<any>)
+    if !exists('g:__fuzzyy_launcher_cache')
+        g:__fuzzyy_launcher_cache = []
+    endif
+    insert(g:__fuzzyy_launcher_cache, { selector: selector, opts: opts, prompt: '' })
+    function('fuzzyy#' .. selector .. '#Start')(opts)
+enddef
+
+export def Resume()
+    if !exists('g:__fuzzyy_launcher_cache')
+        Warn( 'fuzzyy: no previous launch to resume')
+        return
+    endif
+    for e in g:__fuzzyy_launcher_cache
+        if !empty(e.prompt)
+            function('fuzzyy#' .. e.selector .. '#Start')(e.opts)
+            popup.SetPrompt(e.prompt)
+            # trim cache, only save latest with prompt
+            g:__fuzzyy_launcher_cache = [e]
+            return
+        endif
+    endfor
+    # clear cache, no items in cache have saved prompt, so cannot be resumed
+    g:__fuzzyy_launcher_cache = []
+    Warn('fuzzyy: no previous search to resume')
+enddef
+
+export def Save(wins: dict<any>)
+    if !exists('g:__fuzzyy_launcher_cache') || type(wins) != v:t_dict
+        return
+    endif
+    try
+        var prompt_str = popup.GetPrompt()
+        if !empty(prompt_str)
+            g:__fuzzyy_launcher_cache[0].prompt = prompt_str
+        elseif empty(g:__fuzzyy_launcher_cache[0].prompt)
+            # remove from cache when no prompt to save, cannot be resumed
+            remove(g:__fuzzyy_launcher_cache, 0)
+        endif
+    catch
+        Warn('fuzzyy: ' .. v:exception .. ' at ' .. v:throwpoint)
+    endtry
+enddef
+
+def Warn(msg: string)
+    if has('patch-9.0.0321')
+        echow msg
+    else
+        timer_start(100, (_) => {
+            echohl WarningMsg | echo msg | echohl None
+        }, { repeat: 0 })
+    endif
+enddef

--- a/doc/fuzzyy.txt
+++ b/doc/fuzzyy.txt
@@ -126,6 +126,7 @@ COMMANDS                                                       *fuzzyy-commands*
 | FuzzyTags             | search tags in tagfiles(), see `:h tags`
 | FuzzyTagsRoot         | search tags in the project/vcs root directory
 | FuzzyGitFiles         | search files in output from `git ls-files`
+| FuzzyPrevious         | reloads the previous selector and search string
 | FuzzyHelps            | deprecated alias for FuzzyHelp, will be removed
 | FuzzyMRUFiles         | deprecated alias for FuzzyMru, will be removed
 
@@ -151,6 +152,7 @@ MAPPINGS                                                       *fuzzyy-mappings*
   nnoremap <silent> <leader>fh :FuzzyHelp<CR>
   nnoremap <silent> <leader>fi :FuzzyInBuffer<CR>
   nnoremap <silent> <leader>fm :FuzzyMru<CR>
+  nnoremap <silent> <leader>fp :FuzzyPrevious<CR>
   nnoremap <silent> <leader>fr :FuzzyMruCwd<CR>
 <
 

--- a/plugin/fuzzyy.vim
+++ b/plugin/fuzzyy.vim
@@ -111,36 +111,27 @@ highlight default link fuzzyyBorder Normal
 highlight default link fuzzyyMatching Special
 highlight default link fuzzyyPreviewMatch CurSearch
 
-import autoload '../autoload/fuzzyy/commands.vim'
-import autoload '../autoload/fuzzyy/grep.vim'
-import autoload '../autoload/fuzzyy/files.vim'
-import autoload '../autoload/fuzzyy/help.vim'
-import autoload '../autoload/fuzzyy/colors.vim'
-import autoload '../autoload/fuzzyy/inbuffer.vim'
-import autoload '../autoload/fuzzyy/buffers.vim'
-import autoload '../autoload/fuzzyy/highlights.vim'
-import autoload '../autoload/fuzzyy/cmdhistory.vim'
-import autoload '../autoload/fuzzyy/mru.vim'
-import autoload '../autoload/fuzzyy/tags.vim'
 import autoload '../autoload/fuzzyy/utils/selector.vim'
+import autoload '../autoload/fuzzyy/utils/launcher.vim'
 
-command! -nargs=? FuzzyGrep grep.Start(extendnew(windows.grep, { search: <q-args> }))
-command! -nargs=? FuzzyGrepRoot grep.Start(extendnew(windows.grep, { cwd: selector.GetRootDir(), 'search': <q-args> }))
-command! -nargs=0 FuzzyFiles files.Start(windows.files)
-command! -nargs=? FuzzyFilesRoot files.Start(extendnew(windows.files, { cwd: selector.GetRootDir() }))
-command! -nargs=0 FuzzyHelp help.Start(windows.help)
-command! -nargs=0 FuzzyColors colors.Start(windows.colors)
-command! -nargs=? FuzzyInBuffer inbuffer.Start(extendnew(windows.inbuffer, { search: <q-args> }))
-command! -nargs=0 FuzzyCommands commands.Start(windows.commands)
-command! -nargs=0 FuzzyBuffers buffers.Start(windows.buffers)
-command! -nargs=0 FuzzyHighlights highlights.Start(windows.highlights)
-command! -nargs=0 FuzzyGitFiles files.Start(extendnew(windows.files, { command: 'git ls-files' }))
-command! -nargs=0 FuzzyCmdHistory cmdhistory.Start(windows.cmdhistory)
-command! -nargs=0 FuzzyMru mru.Start(windows.mru)
-command! -nargs=0 FuzzyMruCwd mru.Start(extendnew(windows.mru, { cwd: getcwd() }))
-command! -nargs=0 FuzzyMruRoot mru.Start(extendnew(windows.mru, { cwd: selector.GetRootDir() }))
-command! -nargs=0 FuzzyTags tags.Start(windows.tags)
-command! -nargs=0 FuzzyTagsRoot tags.Start(extendnew(windows.tags, { cwd: selector.GetRootDir() }))
+command! -nargs=? FuzzyGrep launcher.Start('grep', extendnew(windows.grep, { search: <q-args> }))
+command! -nargs=? FuzzyGrepRoot launcher.Start('grep', extendnew(windows.grep, { cwd: selector.GetRootDir(), 'search': <q-args> }))
+command! -nargs=0 FuzzyFiles launcher.Start('files', windows.files)
+command! -nargs=? FuzzyFilesRoot launcher.Start('files', extendnew(windows.files, { cwd: selector.GetRootDir() }))
+command! -nargs=0 FuzzyHelp launcher.Start('help', windows.help)
+command! -nargs=0 FuzzyColors launcher.Start('colors', windows.colors)
+command! -nargs=? FuzzyInBuffer launcher.Start('inbuffer', extendnew(windows.inbuffer, { search: <q-args> }))
+command! -nargs=0 FuzzyCommands launcher.Start('commands', windows.commands)
+command! -nargs=0 FuzzyBuffers launcher.Start('buffers', windows.buffers)
+command! -nargs=0 FuzzyHighlights launcher.Start('highlights', windows.highlights)
+command! -nargs=0 FuzzyGitFiles launcher.Start('files', extendnew(windows.files, { command: 'git ls-files' }))
+command! -nargs=0 FuzzyCmdHistory launcher.Start('cmdhistory', windows.cmdhistory)
+command! -nargs=0 FuzzyMru launcher.Start('mru', windows.mru)
+command! -nargs=0 FuzzyMruCwd launcher.Start('mru', extendnew(windows.mru, { cwd: getcwd() }))
+command! -nargs=0 FuzzyMruRoot launcher.Start('mru', extendnew(windows.mru, { cwd: selector.GetRootDir() }))
+command! -nargs=0 FuzzyTags launcher.Start('tags', windows.tags)
+command! -nargs=0 FuzzyTagsRoot launcher.Start('tags', extendnew(windows.tags, { cwd: selector.GetRootDir() }))
+command! -nargs=0 FuzzyPrevious launcher.Resume()
 
 # Deprecated/renamed commands
 def Warn(msg: string)
@@ -171,6 +162,7 @@ if g:fuzzyy_enable_mappings
         '<leader>fh': ':FuzzyHelp<CR>',
         '<leader>fi': ':FuzzyInBuffer<CR>',
         '<leader>fm': ':FuzzyMru<CR>',
+        '<leader>fp': ':FuzzyPrevious<CR>',
         '<leader>fr': ':FuzzyMruCwd<CR>'
     }
     for [lhs, rhs] in items(mappings)


### PR DESCRIPTION
This adds a feature similar to those found in Telescope, LeaderF and FZF.vim to allow the previous selector and search to be reloaded.

The new launcher script is used to start selectors, and caches previous launches, allowing the most recent one which also has some saved input to be resumed. The cache currently only stores one previous launch (the last one that had some associated input and can therefore be resumed).

This could be extended later to allow resumption of specific selectors, but just using the previous one with an some input is a good start.

I'm also thinking of this new launcher script as a general entry point for launching selectors, allowing extensions to register selectors in future (something along the lines of how Telescope extensions work).

Note: some minor changes were required to popup.SetPrompt() to support this feature, it needs to clear any previously inserted text to support commands that allow the prompt to be set, e.g. FuzzyGrep, and needs to invoke the input callback after changing the content of the prompt to work nicely with async searches, e.g. FuzzyFiles.

Also note that the cache of previous launches does not persist across Vim sessions. This is by design, persisting across sessions would need to take into account current working directory, far too complicated (and potentially also raises privacy concerns, so would need to be optional).