### PR TITLE
Add option to set prompt title and set defaults

### DIFF
--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -636,6 +636,13 @@ def PopupPrompt(args: dict<any>): number
     endif
     popup_settext(wid, prompt_opt.displayed_line)
 
+    if has_key(args, 'title') && !empty(args.title)
+        # var title = substitute(prompt_char, '\m.', borderchars[0], 'g') .. args.title
+        var padding = ( popup_getoptions(wid).maxwidth / 2 ) - ( len(args.title) / 2 )
+        var title = repeat([borderchars[0]], padding)->join('') .. args.title
+        popup_setoptions(wid, {title: title})
+    endif
+
     # set cursor
     var mid = matchaddpos(cursor_args.highlight,
     [[1, prompt_char_len + 1 + cursor_args.cur_pos]], 10, -1,  {window: wid})
@@ -773,6 +780,7 @@ export def PopupSelection(opts: dict<any>): dict<any>
         dropdown: dropdown,
         input_cb: has_key(opts, 'input_cb') ? opts.input_cb : null,
         prompt: has_key(opts, 'prompt') ? opts.prompt : '> ',
+        title: has_key(opts, 'prompt_title') ? opts.prompt_title : null,
         zindex: 1010,
     }
     wins.prompt = PopupPrompt(prompt_opts)

--- a/plugin/fuzzyy.vim
+++ b/plugin/fuzzyy.vim
@@ -57,28 +57,45 @@ g:fuzzyy_ripgrep_options = exists('g:fuzzyy_ripgrep_options')
 # you can override it by setting g:fuzzyy_window_layout
 # e.g. let g:fuzzyy_window_layout = { 'files': { 'preview': 0 } }
 var windows: dict<any> = {
-    files: {},
-    grep: {},
-    buffers: {},
-    mru: {},
-    tags: {},
+    files: {
+        prompt_title: 'Find Files'
+    },
+    grep: {
+        prompt_title: 'Live Grep'
+    },
+    buffers: {
+        prompt_title: 'Buffers'
+    },
+    mru: {
+        prompt_title: 'Recent Files'
+    },
+    tags: {
+        prompt_title: 'Tags'
+    },
     highlights: {
+        prompt_title: 'Highlights',
         preview_ratio: 0.7,
     },
     cmdhistory: {
+        prompt_title: 'Command History',
         width: 0.6,
     },
     colors: {
+        prompt_title: 'Colors',
         width: 0.25,
         xoffset: 0.7,
     },
     commands: {
+        prompt_title: 'Commands',
         width: 0.4,
     },
     help: {
+        prompt_title: 'Help',
         preview_ratio: 0.6,
     },
-    inbuffer: {},
+    inbuffer: {
+        prompt_title: 'Lines in Buffer',
+    },
 }
 if exists('g:fuzzyy_window_layout') && type(g:fuzzyy_window_layout) == v:t_dict
     for [key, value] in items(windows)


### PR DESCRIPTION
Similar to telescope.nvim, somewhat experimental, may also warrant
adding a global config option to disable prompt titles, not sure.

Personally I find this very helpful, especially when resuming a
previously loaded selector (see other PR that adds this feature).

Defaults are English only at the moment, but can easily be customised.
