### PR TITLE
Simplify devicons handling for most selectors

### DIFF
--- a/autoload/fuzzyy/buffers.vim
+++ b/autoload/fuzzyy/buffers.vim
@@ -5,7 +5,6 @@ import autoload './utils/devicons.vim'
 
 var buf_dict: dict<any>
 var key_callbacks: dict<any>
-var enable_devicons = devicons.Enabled()
 var _window_width: float
 
 # Options
@@ -29,9 +28,6 @@ def Preview(wid: number, opts: dict<any>)
     if result == ''
         popup_settext(preview_wid, '')
         return
-    endif
-    if enable_devicons
-        result = devicons.RemoveDevicon(result)
     endif
     var file: string
     var lnum: number
@@ -62,9 +58,6 @@ enddef
 def Close(wid: number, result: dict<any>)
     if has_key(result, 'selected_item')
         var buf = result.selected_item
-        if enable_devicons
-            buf = devicons.RemoveDevicon(buf)
-        endif
         var bufnr = buf_dict[buf][1]
         if bufnr != bufnr('$')
             selector.MoveToUsableWindow(bufnr)
@@ -98,26 +91,26 @@ def GetBufList(): list<string>
 enddef
 
 def DeleteSelectedBuffer()
-    var buf = selector.MenuGetCursorItem(true)
+    var buf = selector.MenuGetCursorItem()
     delete(buf)
     if buf == ''
         return
     endif
     execute(':bw ' .. buf)
     var li = GetBufList()
-    selector.UpdateMenu(li, [], 1)
+    selector.UpdateMenu(li, [])
     selector.UpdateList(li)
     selector.RefreshMenu()
 enddef
 
 def CloseSelectedBuffer()
-    var buf = selector.MenuGetCursorItem(true)
+    var buf = selector.MenuGetCursorItem()
     if buf == ''
         return
     endif
     execute(':bw ' .. buf)
     var li = GetBufList()
-    selector.UpdateMenu(li, [], 1)
+    selector.UpdateMenu(li, [])
     selector.UpdateList(li)
     selector.RefreshMenu()
 enddef
@@ -131,9 +124,9 @@ export def Start(opts: dict<any> = {})
     _window_width = get(opts, 'width', 0.8)
 
     var wids = selector.Start(GetBufList(), extend(opts, {
+        devicons: true,
         preview_cb: function('Preview'),
         close_cb: function('Close'),
-        devicons: enable_devicons,
         key_callbacks: extend(selector.split_edit_callbacks, key_callbacks),
     }))
 enddef

--- a/autoload/fuzzyy/files.vim
+++ b/autoload/fuzzyy/files.vim
@@ -25,9 +25,6 @@ def ProcessResult(list_raw: list<string>, ...args: list<any>): list<string>
     else
         li = list_raw
     endif
-    if enable_devicons
-        devicons.AddDevicons(li)
-    endif
     # Hack for Git-Bash / Mingw-w64, Cygwin, and possibly other friends
     # External commands like rg may return paths with Windows file separator,
     # but Vim thinks it has a UNIX environment, so needs UNIX file separator
@@ -37,9 +34,6 @@ enddef
 
 def Select(wid: number, result: list<any>)
     var relative_path = result[0]
-    if enable_devicons
-        relative_path = devicons.RemoveDevicon(relative_path)
-    endif
     var path = cwd .. '/' .. relative_path
     selector.MoveToUsableWindow()
     exe 'edit ' .. fnameescape(path)
@@ -85,9 +79,6 @@ enddef
 
 def Preview(wid: number, opts: dict<any>)
     var result = opts.cursor_item
-    if enable_devicons
-        result = devicons.RemoveDevicon(result)
-    endif
     if !has_key(opts.win_opts.partids, 'preview')
         return
     endif

--- a/autoload/fuzzyy/grep.vim
+++ b/autoload/fuzzyy/grep.vim
@@ -294,9 +294,6 @@ enddef
 
 def Preview(wid: number, opts: dict<any>)
     var result = opts.cursor_item
-    if enable_devicons
-        result = devicons.RemoveDevicon(result)
-    endif
     var last_item = opts.last_cursor_item
     var [relative_path, linenr, colnr] = ParseResult(result)
     var last_path: string
@@ -332,9 +329,6 @@ def Select(wid: number, result: list<any>)
     var [relative_path, line, col] = ParseResult(result[0])
     if relative_path == null
         return
-    endif
-    if enable_devicons
-        relative_path = devicons.RemoveDevicon(relative_path)
     endif
     var path = cwd .. '/' .. relative_path
     selector.MoveToUsableWindow()
@@ -389,7 +383,6 @@ def UpdateMenu(...li: list<any>)
     endif
 
     if enable_devicons
-        devicons.AddDevicons(strs)
         var hl_offset = devicons.GetDeviconOffset()
         hl_list = reduce(hl_list, (a, v) => {
             v[1] += hl_offset

--- a/autoload/fuzzyy/mru.vim
+++ b/autoload/fuzzyy/mru.vim
@@ -5,7 +5,6 @@ import autoload './utils/previewer.vim'
 import autoload './utils/devicons.vim'
 
 var mru_origin_list: list<string>
-var enable_devicons = devicons.Enabled()
 var cwd: string
 var cwd_only: bool
 var cwdlen: number
@@ -21,9 +20,6 @@ var dir_exclude = exists('g:fuzzyy_mru_exclude_dir')
 
 def Preview(wid: number, opts: dict<any>)
     var result = opts.cursor_item
-    if enable_devicons
-        result = devicons.RemoveDevicon(result)
-    endif
     if !has_key(opts.win_opts.partids, 'preview')
         return
     endif
@@ -37,9 +33,6 @@ enddef
 def Close(wid: number, result: dict<any>)
     if has_key(result, 'selected_item')
         var path = result['selected_item']
-        if enable_devicons
-            path = devicons.RemoveDevicon(path)
-        endif
         selector.MoveToUsableWindow()
         if cwd_only
             exe 'edit ' cwd .. '/' .. fnameescape(path)
@@ -66,7 +59,7 @@ def ToggleScope()
             return acc
         }, [])
     endif
-    selector.UpdateMenu(mru_list, [], 1)
+    selector.UpdateMenu(mru_list, [])
 enddef
 
 var key_callbacks = {
@@ -124,9 +117,9 @@ export def Start(opts: dict<any> = {})
 
     var wids = selector.Start(mru_list, extend(opts, {
         async: true,
+        devicons: true,
         close_cb: function('Close'),
         preview_cb: function('Preview'),
-        devicons: enable_devicons,
         key_callbacks: extend(key_callbacks, selector.split_edit_callbacks),
     }))
     menu_wid = wids.menu

--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -3,12 +3,14 @@ vim9script
 scriptencoding utf-8
 
 import autoload './colors.vim'
+import autoload './devicons.vim'
 import autoload './launcher.vim'
 
 var popup_wins: dict<any>
 var wins = { menu: -1, prompt: -1, preview: -1, info: -1 }
 var t_ve: string
 var hlcursor: dict<any>
+var enable_devicons: bool
 export var active = false
 
 # user can register callback for any key
@@ -177,6 +179,9 @@ def MenuCursorContentChangeCb(): number
     var bufnr = popup_wins[wins.menu].bufnr
     var cursorlinepos = line('.', wins.menu)
     var linetext = getbufline(bufnr, cursorlinepos, cursorlinepos)[0]
+    if enable_devicons
+        linetext = devicons.RemoveDevicon(linetext)
+    endif
     if popup_wins[wins.menu].cursor_item == linetext
         return 0
     endif
@@ -352,6 +357,8 @@ def MenuFilter(wid: number, key: string): number
         var linetext = getbufline(bufnr, pos.line, pos.line)[0]
         if linetext == ''
             popup_close(wid)
+        elseif enable_devicons
+            popup_close(wid, [devicons.RemoveDevicon(linetext)])
         else
             popup_close(wid, [linetext])
         endif
@@ -375,6 +382,8 @@ def MenuFilter(wid: number, key: string): number
         var linetext = getbufline(bufnr, cursorlinepos, cursorlinepos)[0]
         if linetext == ''
             popup_close(wid)
+        elseif enable_devicons
+            popup_close(wid, [devicons.RemoveDevicon(linetext)])
         else
             popup_close(wid, [linetext])
         endif
@@ -716,6 +725,7 @@ export def PopupSelection(opts: dict<any>): dict<any>
     endif
     active = true
     key_callbacks = has_key(opts, 'key_callbacks') ? opts.key_callbacks : {}
+    enable_devicons = has_key(opts, 'devicons') ? opts.devicons && devicons.Enabled() : 0
     var has_preview = has_key(opts, 'preview') ? opts.preview : 1
 
     var width: any = 0.8

--- a/autoload/fuzzyy/utils/selector.vim
+++ b/autoload/fuzzyy/utils/selector.vim
@@ -32,14 +32,10 @@ export var total_results: number
 # params:
 # - str_list: list of string to be displayed in the menu window
 # - hl_list: list of highlight positions
-# - opts: dict of options
-#       - add devicons: add devicons to every entry
-export def UpdateMenu(str_list: list<string>, hl_list: list<list<any>>, ...opts: list<any>)
+export def UpdateMenu(str_list: list<string>, hl_list: list<list<any>>)
     var new_list = copy(str_list)
     if enable_devicons
-        if len(opts) > 0 && opts[0] == 1
-            devicons.AddDevicons(new_list)
-        endif
+        devicons.AddDevicons(new_list)
         popup.MenuSetText(new_list)
         popup.MenuSetHl('select', hl_list)
         devicons.AddColor(menu_wid)
@@ -54,14 +50,12 @@ enddef
 # - stripped: get the line after striping the devicon or any other prefix
 # return:
 # - the line under the cursor
-export def MenuGetCursorItem(stripped: bool): string
+export def MenuGetCursorItem(): string
     var bufnr = winbufnr(wins.menu)
     var cursorlinepos = line('.', wins.menu)
     var bufline = getbufline(bufnr, cursorlinepos, cursorlinepos)[0]
-    if stripped
-        if enable_devicons
-            bufline = devicons.RemoveDevicon(bufline)
-        endif
+    if enable_devicons
+        bufline = devicons.RemoveDevicon(bufline)
     endif
     return bufline
 enddef
@@ -352,9 +346,6 @@ enddef
 def CloseTab(wid: number, result: dict<any>)
     if !empty(get(result, 'cursor_item', ''))
         var [buf, line, col] = split(result.cursor_item .. ':0:0', ':')[0 : 2]
-        if enable_devicons
-            buf = devicons.RemoveDevicon(buf)
-        endif
         var bufnr = bufnr(buf)
         if bufnr > 0 && !filereadable(buf)
             # for special buffers that cannot be edited
@@ -380,9 +371,6 @@ enddef
 def CloseVSplit(wid: number, result: dict<any>)
     if !empty(get(result, 'cursor_item', ''))
         var [buf, line, col] = split(result.cursor_item .. ':0:0', ':')[0 : 2]
-        if enable_devicons
-            buf = devicons.RemoveDevicon(buf)
-        endif
         var bufnr = bufnr(buf)
         if bufnr > 0 && !filereadable(buf)
             # for special buffers that cannot be edited
@@ -409,9 +397,6 @@ enddef
 def CloseSplit(wid: number, result: dict<any>)
     if !empty(get(result, 'cursor_item', ''))
         var [buf, line, col] = split(result.cursor_item .. ':0:0', ':')[0 : 2]
-        if enable_devicons
-            buf = devicons.RemoveDevicon(buf)
-        endif
         var bufnr = bufnr(buf)
         if bufnr > 0 && !filereadable(buf)
             # for special buffers that cannot be edited


### PR DESCRIPTION
Move more of the code for handling devicons into core files so most
selectors don't need to worry about the details, set `devicons: true`
in opts to selector.Start() and it just works; devicons are added to
the results in the menu, and then removed from selected items passed
to preview, select and close callbacks.

Some custom handling remains within the files and grep selectors as they
currently require custom code to parse results when updating the menu.
Will revisit another time and see if I can remove the need for this.
