### PR TITLE
Simplify callbacks

### DIFF
--- a/autoload/fuzzyy/builtin/buffers.vim
+++ b/autoload/fuzzyy/builtin/buffers.vim
@@ -26,13 +26,12 @@ if has_key(keymaps, "delete_buffer") && !empty(keymaps.delete_buffer) && empty(k
 endif
 
 def Preview(wid: number, opts: dict<any>)
-    var result = opts.cursor_item
-    if !has_key(opts.win_opts.partids, 'preview')
+    if wid == -1
         return
     endif
-    var preview_wid = opts.win_opts.partids['preview']
+    var result = opts.cursor_item
     if result == ''
-        popup_settext(preview_wid, '')
+        popup_settext(wid, '')
         return
     endif
     var file: string
@@ -41,24 +40,24 @@ def Preview(wid: number, opts: dict<any>)
     lnum = buf_dict[result][2]
     if !filereadable(file)
         if file == ''
-            popup_settext(preview_wid, '')
+            popup_settext(wid, '')
         else
-            popup_settext(preview_wid, file .. ' not found')
+            popup_settext(wid, file .. ' not found')
         endif
         return
     endif
-    popup_setoptions(preview_wid, {title: fnamemodify(file, ':t')})
+    popup_setoptions(wid, {title: fnamemodify(file, ':t')})
     var bufnr = buf_dict[result][1]
     var ft = getbufvar(bufnr, '&filetype')
     var fileraw = readfile(file)
-    var preview_bufnr = winbufnr(preview_wid)
-    popup_settext(preview_wid, fileraw)
+    var preview_bufnr = winbufnr(wid)
+    popup_settext(wid, fileraw)
     try
         setbufvar(preview_bufnr, '&syntax', ft)
     catch
     endtry
-    win_execute(preview_wid, 'norm! ' .. lnum .. 'G')
-    win_execute(preview_wid, 'norm! zz')
+    win_execute(wid, 'norm! ' .. lnum .. 'G')
+    win_execute(wid, 'norm! zz')
 enddef
 
 def Close(wid: number, result: dict<any>)

--- a/autoload/fuzzyy/builtin/buffers.vim
+++ b/autoload/fuzzyy/builtin/buffers.vim
@@ -25,11 +25,10 @@ if has_key(keymaps, "delete_buffer") && !empty(keymaps.delete_buffer) && empty(k
     keymaps.delete_file = keymaps.delete_buffer
 endif
 
-def Preview(wid: number, opts: dict<any>)
+def Preview(wid: number, result: string, opts: dict<any>)
     if wid == -1
         return
     endif
-    var result = opts.cursor_item
     if result == ''
         popup_settext(wid, '')
         return

--- a/autoload/fuzzyy/builtin/buffers.vim
+++ b/autoload/fuzzyy/builtin/buffers.vim
@@ -25,7 +25,7 @@ if has_key(keymaps, "delete_buffer") && !empty(keymaps.delete_buffer) && empty(k
     keymaps.delete_file = keymaps.delete_buffer
 endif
 
-def Preview(wid: number, result: string, opts: dict<any>)
+def Preview(wid: number, result: string)
     if wid == -1
         return
     endif

--- a/autoload/fuzzyy/builtin/buffers.vim
+++ b/autoload/fuzzyy/builtin/buffers.vim
@@ -59,14 +59,12 @@ def Preview(wid: number, result: string, opts: dict<any>)
     win_execute(wid, 'norm! zz')
 enddef
 
-def Close(wid: number, result: dict<any>)
-    if has_key(result, 'selected_item')
-        var buf = result.selected_item
-        var bufnr = buf_dict[buf][1]
-        if bufnr != bufnr('$')
-            selector.MoveToUsableWindow(bufnr)
-            execute 'buffer' bufnr
-        endif
+def Select(wid: number, result: list<any>)
+    var buf = result[0]
+    var bufnr = buf_dict[buf][1]
+    if bufnr != bufnr('$')
+        selector.MoveToUsableWindow(bufnr)
+        execute 'buffer' bufnr
     endif
 enddef
 
@@ -140,7 +138,7 @@ export def Start(opts: dict<any> = {})
     var wids = selector.Start(GetBufList(), extend(opts, {
         devicons: true,
         preview_cb: function('Preview'),
-        close_cb: function('Close'),
+        select_cb: function('Select'),
         key_callbacks: extend(selector.split_edit_callbacks, key_callbacks),
     }))
 enddef

--- a/autoload/fuzzyy/builtin/colors.vim
+++ b/autoload/fuzzyy/builtin/colors.vim
@@ -13,7 +13,7 @@ def GetColors(): list<string>
    )))
 enddef
 
-def Preview(wid: number, result: string, opts: dict<any>)
+def Preview(wid: number, result: string)
     var color = result
     &bg = old_bg
     noa execute 'colorscheme ' .. color
@@ -29,7 +29,7 @@ def Select(wid: number, result: list<any>)
     changed = true
 enddef
 
-def Close(wid: number, result: dict<any>)
+def Close(wid: number)
     if !changed
         noa &bg = old_bg
         execute 'colorscheme ' .. old_color

--- a/autoload/fuzzyy/builtin/colors.vim
+++ b/autoload/fuzzyy/builtin/colors.vim
@@ -4,6 +4,7 @@ import autoload '../utils/selector.vim'
 
 var old_color: string
 var old_bg: string
+var changed: bool
 
 def GetColors(): list<string>
    return uniq(sort(map(
@@ -18,17 +19,20 @@ def Preview(wid: number, result: string, opts: dict<any>)
     noa execute 'colorscheme ' .. color
 enddef
 
+def Select(wid: number, result: list<any>)
+    var color = result[0]
+    var bg: string
+    if color =~# 'light$'
+        noa &bg = 'light'
+    endif
+    execute 'colorscheme ' .. color
+    changed = true
+enddef
+
 def Close(wid: number, result: dict<any>)
-    if !has_key(result, 'selected_item')
+    if !changed
         noa &bg = old_bg
         execute 'colorscheme ' .. old_color
-    else
-        var color = result.selected_item
-        var bg: string
-        if color =~# 'light$'
-            noa &bg = 'light'
-        endif
-        execute 'colorscheme ' .. color
     endif
 enddef
 
@@ -39,6 +43,7 @@ export def Start(opts: dict<any> = {})
 
     var wids = selector.Start(colors, extend(opts, {
         preview_cb: function('Preview'),
+        select_cb: function('Select'),
         close_cb: function('Close'),
         preview: 0
     }))

--- a/autoload/fuzzyy/builtin/colors.vim
+++ b/autoload/fuzzyy/builtin/colors.vim
@@ -12,8 +12,8 @@ def GetColors(): list<string>
    )))
 enddef
 
-def Preview(wid: number, result: dict<any>)
-    var color = result.cursor_item
+def Preview(wid: number, result: string, opts: dict<any>)
+    var color = result
     &bg = old_bg
     noa execute 'colorscheme ' .. color
 enddef

--- a/autoload/fuzzyy/builtin/files.vim
+++ b/autoload/fuzzyy/builtin/files.vim
@@ -77,11 +77,10 @@ def Input(wid: number, opts: dict<any>)
     endif
 enddef
 
-def Preview(wid: number, opts: dict<any>)
+def Preview(wid: number, result: string, opts: dict<any>)
     if wid == -1
         return
     endif
-    var result = opts.cursor_item
     if result == ''
         previewer.PreviewText(wid, '')
         return

--- a/autoload/fuzzyy/builtin/files.vim
+++ b/autoload/fuzzyy/builtin/files.vim
@@ -58,7 +58,7 @@ def AsyncCb(result: list<any>)
     popup_setoptions(menu_wid, {title: selector.total_results})
 enddef
 
-def Input(wid: number, result: string, opts: dict<any>)
+def Input(wid: number, result: string)
     cur_pattern = result
 
     # when in loading state, files_update_menu will handle the input
@@ -76,7 +76,7 @@ def Input(wid: number, result: string, opts: dict<any>)
     endif
 enddef
 
-def Preview(wid: number, result: string, opts: dict<any>)
+def Preview(wid: number, result: string)
     if wid == -1
         return
     endif
@@ -150,7 +150,7 @@ def UpdateMenu(...li: list<any>)
     endif
 enddef
 
-def Close(wid: number, opts: dict<any>)
+def Close(wid: number)
     if type(jid) == v:t_job && job_status(jid) == 'run'
         job_stop(jid)
     endif

--- a/autoload/fuzzyy/builtin/files.vim
+++ b/autoload/fuzzyy/builtin/files.vim
@@ -78,18 +78,17 @@ def Input(wid: number, opts: dict<any>)
 enddef
 
 def Preview(wid: number, opts: dict<any>)
-    var result = opts.cursor_item
-    if !has_key(opts.win_opts.partids, 'preview')
+    if wid == -1
         return
     endif
-    var preview_wid = opts.win_opts.partids['preview']
+    var result = opts.cursor_item
     if result == ''
-        previewer.PreviewText(preview_wid, '')
+        previewer.PreviewText(wid, '')
         return
     endif
     var path = cwd .. '/' .. result
-    previewer.PreviewFile(preview_wid, path, { max: 1000 })
-    win_execute(preview_wid, 'norm! gg')
+    previewer.PreviewFile(wid, path, { max: 1000 })
+    win_execute(wid, 'norm! gg')
 enddef
 
 def JobStart(path: string, cmd: string)

--- a/autoload/fuzzyy/builtin/files.vim
+++ b/autoload/fuzzyy/builtin/files.vim
@@ -58,9 +58,8 @@ def AsyncCb(result: list<any>)
     popup_setoptions(menu_wid, {title: selector.total_results})
 enddef
 
-def Input(wid: number, opts: dict<any>)
-    var pattern = opts.str
-    cur_pattern = pattern
+def Input(wid: number, result: string, opts: dict<any>)
+    cur_pattern = result
 
     # when in loading state, files_update_menu will handle the input
     if in_loading
@@ -69,7 +68,7 @@ def Input(wid: number, opts: dict<any>)
 
     var file_list = cur_result
 
-    if pattern != ''
+    if cur_pattern != ''
         selector.FuzzySearchAsync(cur_result, cur_pattern, 200, function('AsyncCb'))
     else
         selector.UpdateMenu(ProcessResult(cur_result, 100), [])

--- a/autoload/fuzzyy/builtin/grep.vim
+++ b/autoload/fuzzyy/builtin/grep.vim
@@ -293,6 +293,9 @@ def UpdatePreviewHl()
 enddef
 
 def Preview(wid: number, opts: dict<any>)
+    if wid == -1
+        return
+    endif
     var result = opts.cursor_item
     var last_item = opts.last_cursor_item
     var [relative_path, linenr, colnr] = ParseResult(result)

--- a/autoload/fuzzyy/builtin/grep.vim
+++ b/autoload/fuzzyy/builtin/grep.vim
@@ -151,6 +151,7 @@ var update_tid = 0
 var last_pattern = ''
 var last_result_len = -1
 var last_result = []
+var last_path: string
 var cur_dict = {}
 var jid: job
 var pid: number
@@ -296,19 +297,7 @@ def Preview(wid: number, result: string, opts: dict<any>)
     if wid == -1
         return
     endif
-    var last_item = opts.last_cursor_item
     var [relative_path, linenr, colnr] = ParseResult(result)
-    var last_path: string
-    var last_linenr: number
-    if type(last_item) == v:t_string  && type(last_item) == v:t_string && last_item != ''
-        try
-        [last_path, last_linenr, _] = ParseResult(last_item)
-        catch
-            return
-        endtry
-    else
-        [last_path, last_linenr] = ['', -1]
-    endif
     cur_menu_item = result
 
     if relative_path == null
@@ -320,10 +309,9 @@ def Preview(wid: number, result: string, opts: dict<any>)
     if path != last_path
         previewer.PreviewFile(preview_wid, path)
     endif
-    if path != last_path || linenr != last_linenr
-        win_execute(preview_wid, 'norm! ' .. linenr .. 'G')
-        win_execute(preview_wid, 'norm! zz')
-    endif
+    last_path = path
+    win_execute(preview_wid, 'norm! ' .. linenr .. 'G')
+    win_execute(preview_wid, 'norm! zz')
     UpdatePreviewHl()
 enddef
 
@@ -429,6 +417,7 @@ export def Start(opts: dict<any> = {})
     last_pattern = ''
     last_result_len = -1
     last_result = []
+    last_path = ''
     cur_dict = {}
 
     var wids = selector.Start([], extend(opts, {

--- a/autoload/fuzzyy/builtin/grep.vim
+++ b/autoload/fuzzyy/builtin/grep.vim
@@ -292,11 +292,10 @@ def UpdatePreviewHl()
     matchaddpos('fuzzyyPreviewMatch', hl_list, 9999, -1,  {window: preview_wid})
 enddef
 
-def Preview(wid: number, opts: dict<any>)
+def Preview(wid: number, result: string, opts: dict<any>)
     if wid == -1
         return
     endif
-    var result = opts.cursor_item
     var last_item = opts.last_cursor_item
     var [relative_path, linenr, colnr] = ParseResult(result)
     var last_path: string

--- a/autoload/fuzzyy/builtin/grep.vim
+++ b/autoload/fuzzyy/builtin/grep.vim
@@ -277,7 +277,7 @@ def ResultHandle(lists: list<any>): list<any>
 enddef
 
 # async version
-def Input(wid: number, result: string, opts: dict<any>)
+def Input(wid: number, result: string)
     cur_pattern = result
     JobStart(result)
 enddef
@@ -292,7 +292,7 @@ def UpdatePreviewHl()
     matchaddpos('fuzzyyPreviewMatch', hl_list, 9999, -1,  {window: preview_wid})
 enddef
 
-def Preview(wid: number, result: string, opts: dict<any>)
+def Preview(wid: number, result: string)
     if wid == -1
         return
     endif
@@ -385,7 +385,7 @@ def UpdateMenu(...li: list<any>)
     last_result_len = cur_result_len
 enddef
 
-def Close(wid: number, opts: dict<any>)
+def Close(wid: number)
     timer_stop(update_tid)
     if type(jid) == v:t_job && job_status(jid) == 'run'
         job_stop(jid)

--- a/autoload/fuzzyy/builtin/grep.vim
+++ b/autoload/fuzzyy/builtin/grep.vim
@@ -277,10 +277,9 @@ def ResultHandle(lists: list<any>): list<any>
 enddef
 
 # async version
-def Input(wid: number, opts: dict<any>)
-    var pattern = opts.str
-    cur_pattern = pattern
-    JobStart(pattern)
+def Input(wid: number, result: string, opts: dict<any>)
+    cur_pattern = result
+    JobStart(result)
 enddef
 
 def UpdatePreviewHl()

--- a/autoload/fuzzyy/builtin/grep.vim
+++ b/autoload/fuzzyy/builtin/grep.vim
@@ -385,7 +385,7 @@ def UpdateMenu(...li: list<any>)
     last_result_len = cur_result_len
 enddef
 
-def CloseCb(...li: list<any>)
+def Close(wid: number, opts: dict<any>)
     timer_stop(update_tid)
     if type(jid) == v:t_job && job_status(jid) == 'run'
         job_stop(jid)
@@ -423,7 +423,7 @@ export def Start(opts: dict<any> = {})
         select_cb: function('Select'),
         input_cb: function('Input'),
         preview_cb: function('Preview'),
-        close_cb: function('CloseCb'),
+        close_cb: function('Close'),
         devicons: enable_devicons,
         key_callbacks: selector.split_edit_callbacks
      }))

--- a/autoload/fuzzyy/builtin/help.vim
+++ b/autoload/fuzzyy/builtin/help.vim
@@ -11,25 +11,24 @@ def EscQuotes(str: string): string
 enddef
 
 def Preview(wid: number, opts: dict<any>)
+    if wid == -1
+        return
+    endif
     var result = opts.cursor_item
-    if !has_key(opts.win_opts.partids, 'preview')
-        return
-    endif
-    var preview_wid = opts.win_opts.partids['preview']
     if result == ''
-        popup_settext(preview_wid, '')
+        popup_settext(wid, '')
         return
     endif
-    var preview_bufnr = winbufnr(preview_wid)
-    setbufvar(preview_bufnr, '&syntax', 'help')
+    var bufnr = winbufnr(wid)
+    setbufvar(bufnr, '&syntax', 'help')
     var tag_file = tag_files[tag_table[result][2]]
     # Note: forward slash path separator tested on Windows, works fine
     var doc_file = fnamemodify(tag_file, ':h') .. '/' .. tag_table[result][0]
-    popup_settext(preview_wid, readfile(doc_file))
-    popup_setoptions(preview_wid, {title: fnamemodify(doc_file, ':t')})
+    popup_settext(wid, readfile(doc_file))
+    popup_setoptions(wid, {title: fnamemodify(doc_file, ':t')})
     var tag_name = substitute(tag_table[result][1], '\v^(\/\*)(.*)(\*)$', '\2', '')
-    win_execute(preview_wid, "exec 'norm! ' .. search('\\m\\*" .. EscQuotes(tag_name) .. "\\*\\C', 'w')")
-    win_execute(preview_wid, 'norm! zz')
+    win_execute(wid, "exec 'norm! ' .. search('\\m\\*" .. EscQuotes(tag_name) .. "\\*\\C', 'w')")
+    win_execute(wid, 'norm! zz')
 enddef
 
 def CloseCb(wid: number, args: dict<any>)

--- a/autoload/fuzzyy/builtin/help.vim
+++ b/autoload/fuzzyy/builtin/help.vim
@@ -10,7 +10,7 @@ def EscQuotes(str: string): string
     return substitute(str, "'", "''", 'g')
 enddef
 
-def Preview(wid: number, result: string, opts: dict<any>)
+def Preview(wid: number, result: string)
     if wid == -1
         return
     endif

--- a/autoload/fuzzyy/builtin/help.vim
+++ b/autoload/fuzzyy/builtin/help.vim
@@ -30,20 +30,18 @@ def Preview(wid: number, result: string, opts: dict<any>)
     win_execute(wid, 'norm! zz')
 enddef
 
-def CloseCb(wid: number, args: dict<any>)
-    if has_key(args, 'selected_item')
-        var tag = args.selected_item
-        var tag_data = tag_table[tag]
-        try
-            # try to open the file and jump to tag first, allows for edge cases
-            # where duplicate tags exist and Fuzzyy finds the tag that Vim does
-            # not consider "best" match, then previews one and opens the other
-            exe ':help ' .. tag_data[0]
-            exe ':tag ' .. tag_data[1]
-        catch
-            exe ':help ' .. tag
-        endtry
-    endif
+def Select(wid: number, result: list<any>)
+    var tag = result[0]
+    var tag_data = tag_table[tag]
+    try
+        # try to open the file and jump to tag first, allows for edge cases
+        # where duplicate tags exist and Fuzzyy finds the tag that Vim does
+        # not consider "best" match, then previews one and opens the other
+        exe ':help ' .. tag_data[0]
+        exe ':tag ' .. tag_data[1]
+    catch
+        exe ':help ' .. tag
+    endtry
 enddef
 
 export def Start(opts: dict<any> = {})
@@ -61,7 +59,7 @@ export def Start(opts: dict<any> = {})
     var wids = selector.Start(keys(tag_table), extend(opts, {
         async: true,
         preview_cb: function('Preview'),
-        close_cb: function('CloseCb'),
+        select_cb: function('Select'),
     }))
     menu_wid = wids.menu
 enddef

--- a/autoload/fuzzyy/builtin/help.vim
+++ b/autoload/fuzzyy/builtin/help.vim
@@ -10,11 +10,10 @@ def EscQuotes(str: string): string
     return substitute(str, "'", "''", 'g')
 enddef
 
-def Preview(wid: number, opts: dict<any>)
+def Preview(wid: number, result: string, opts: dict<any>)
     if wid == -1
         return
     endif
-    var result = opts.cursor_item
     if result == ''
         popup_settext(wid, '')
         return

--- a/autoload/fuzzyy/builtin/highlights.vim
+++ b/autoload/fuzzyy/builtin/highlights.vim
@@ -6,7 +6,7 @@ import autoload '../utils/selector.vim'
 var hl_meta: dict<any>
 var preview_wid: number
 
-def Preview(wid: number, result: string, opts: dict<any>)
+def Preview(wid: number, result: string)
     if wid == -1
         return
     endif

--- a/autoload/fuzzyy/builtin/highlights.vim
+++ b/autoload/fuzzyy/builtin/highlights.vim
@@ -7,15 +7,15 @@ var hl_meta: dict<any>
 var preview_wid: number
 
 def Preview(wid: number, opts: dict<any>)
+    if wid == -1
+        return
+    endif
     if !has_key(hl_meta, opts.cursor_item)
         return
     endif
-    if !has_key(opts.win_opts.partids, 'preview')
-        return
-    endif
     var line = hl_meta[opts.cursor_item][0]
-    win_execute(preview_wid, 'normal! ' .. line .. 'G')
-    win_execute(preview_wid, 'normal! zz')
+    win_execute(wid, 'normal! ' .. line .. 'G')
+    win_execute(wid, 'normal! zz')
 enddef
 
 def Close(wid: number, result: dict<any>)

--- a/autoload/fuzzyy/builtin/highlights.vim
+++ b/autoload/fuzzyy/builtin/highlights.vim
@@ -18,10 +18,8 @@ def Preview(wid: number, result: string, opts: dict<any>)
     win_execute(wid, 'normal! zz')
 enddef
 
-def Close(wid: number, result: dict<any>)
-    if has_key(result, 'selected_item')
-        setreg('*', result.selected_item)
-    endif
+def Select(wid: number, result: list<any>)
+    setreg('*', result[0])
 enddef
 
 def TogglePreviewBg()
@@ -58,7 +56,7 @@ export def Start(opts: dict<any> = {})
 
     var wids = selector.Start(keys(hl_meta), extend(opts, {
         preview_cb: function('Preview'),
-        close_cb: function('Close'),
+        select_cb: function('Select'),
         key_callbacks: key_callbacks,
     }))
 

--- a/autoload/fuzzyy/builtin/highlights.vim
+++ b/autoload/fuzzyy/builtin/highlights.vim
@@ -6,14 +6,14 @@ import autoload '../utils/selector.vim'
 var hl_meta: dict<any>
 var preview_wid: number
 
-def Preview(wid: number, opts: dict<any>)
+def Preview(wid: number, result: string, opts: dict<any>)
     if wid == -1
         return
     endif
-    if !has_key(hl_meta, opts.cursor_item)
+    if !has_key(hl_meta, result)
         return
     endif
-    var line = hl_meta[opts.cursor_item][0]
+    var line = hl_meta[result][0]
     win_execute(wid, 'normal! ' .. line .. 'G')
     win_execute(wid, 'normal! zz')
 enddef

--- a/autoload/fuzzyy/builtin/inbuffer.vim
+++ b/autoload/fuzzyy/builtin/inbuffer.vim
@@ -15,11 +15,10 @@ def Select(wid: number, result: list<any>)
     norm! zz
 enddef
 
-def Preview(wid: number, opts: dict<any>)
+def Preview(wid: number, result: string, opts: dict<any>)
     if wid == -1
         return
     endif
-    var result = opts.cursor_item
     if result == ''
         popup_settext(wid, '')
         return

--- a/autoload/fuzzyy/builtin/inbuffer.vim
+++ b/autoload/fuzzyy/builtin/inbuffer.vim
@@ -34,34 +34,34 @@ def Preview(wid: number, result: string, opts: dict<any>)
     win_execute(wid, 'norm! zz')
 enddef
 
-def CloseTab(wid: number, result: dict<any>)
-    if !empty(get(result, 'cursor_item', ''))
-        var line = str2nr(split(result.cursor_item, '│')[0])
+def SelectTab(wid: number, result: list<any>)
+    if !empty(result) && !empty(result[0])
+        var line = str2nr(split(result[0], '│')[0])
         exe 'tabnew ' .. fnameescape(file_name)
         exe 'norm! ' .. line .. 'G'
         exe 'norm! zz'
     endif
 enddef
 
-def CloseVSplit(wid: number, result: dict<any>)
-    if !empty(get(result, 'cursor_item', ''))
-        var line = str2nr(split(result.cursor_item, '│')[0])
+def SelectVSplit(wid: number, result: list<any>)
+    if !empty(result) && !empty(result[0])
+        var line = str2nr(split(result[0], '│')[0])
         exe 'vsplit ' .. fnameescape(file_name)
         exe 'norm! ' .. line .. 'G'
         exe 'norm! zz'
     endif
 enddef
 
-def CloseSplit(wid: number, result: dict<any>)
-    if !empty(get(result, 'cursor_item', ''))
-        var line = str2nr(split(result.cursor_item, '│')[0])
+def SelectSplit(wid: number, result: list<any>)
+    if !empty(result) && !empty(result[0])
+        var line = str2nr(split(result[0], '│')[0])
         exe 'split ' .. fnameescape(file_name)
         exe 'norm! ' .. line .. 'G'
         exe 'norm! zz'
     endif
 enddef
 
-def CloseQuickFix(wid: number, result: dict<any>)
+def SelectQuickFix(wid: number, result: list<any>)
     var bufnr = winbufnr(wid)
     var lines: list<any>
     lines = reverse(getbufline(bufnr, 1, "$"))
@@ -80,23 +80,23 @@ def CloseQuickFix(wid: number, result: dict<any>)
 enddef
 
 def SetVSplitClose()
-    selector.ReplaceCloseCb(function('CloseVSplit'))
-    selector.Close()
+    selector.ReplaceSelectCb(function('SelectVSplit'))
+    selector.CloseWithSelection()
 enddef
 
 def SetSplitClose()
-    selector.ReplaceCloseCb(function('CloseSplit'))
-    selector.Close()
+    selector.ReplaceSelectCb(function('SelectSplit'))
+    selector.CloseWithSelection()
 enddef
 
 def SetTabClose()
-    selector.ReplaceCloseCb(function('CloseTab'))
-    selector.Close()
+    selector.ReplaceSelectCb(function('SelectTab'))
+    selector.CloseWithSelection()
 enddef
 
 def SetQuickFixClose()
-    selector.ReplaceCloseCb(function('CloseQuickFix'))
-    selector.Close()
+    selector.ReplaceSelectCb(function('SelectQuickFix'))
+    selector.CloseWithSelection()
 enddef
 
 var split_edit_callbacks = {

--- a/autoload/fuzzyy/builtin/inbuffer.vim
+++ b/autoload/fuzzyy/builtin/inbuffer.vim
@@ -15,7 +15,7 @@ def Select(wid: number, result: list<any>)
     norm! zz
 enddef
 
-def Preview(wid: number, result: string, opts: dict<any>)
+def Preview(wid: number, result: string)
     if wid == -1
         return
     endif

--- a/autoload/fuzzyy/builtin/inbuffer.vim
+++ b/autoload/fuzzyy/builtin/inbuffer.vim
@@ -16,24 +16,23 @@ def Select(wid: number, result: list<any>)
 enddef
 
 def Preview(wid: number, opts: dict<any>)
+    if wid == -1
+        return
+    endif
     var result = opts.cursor_item
-    if !has_key(opts.win_opts.partids, 'preview')
-        return
-    endif
-    var preview_wid = opts.win_opts.partids['preview']
     if result == ''
-        popup_settext(preview_wid, '')
+        popup_settext(wid, '')
         return
     endif
-    var preview_bufnr = winbufnr(preview_wid)
+    var preview_bufnr = winbufnr(wid)
     var lnum = split(trim(result[0 : 10]), ' ')[0]
-    if popup_getpos(preview_wid).lastline == 1
-        popup_setoptions(preview_wid, {title: fnamemodify(file_name, ':t')})
-        popup_settext(preview_wid, raw_lines)
+    if popup_getpos(wid).lastline == 1
+        popup_setoptions(wid, {title: fnamemodify(file_name, ':t')})
+        popup_settext(wid, raw_lines)
         setbufvar(preview_bufnr, '&syntax', file_type)
     endif
-    win_execute(preview_wid, 'norm! ' .. lnum .. 'G')
-    win_execute(preview_wid, 'norm! zz')
+    win_execute(wid, 'norm! ' .. lnum .. 'G')
+    win_execute(wid, 'norm! zz')
 enddef
 
 def CloseTab(wid: number, result: dict<any>)

--- a/autoload/fuzzyy/builtin/mru.vim
+++ b/autoload/fuzzyy/builtin/mru.vim
@@ -19,15 +19,14 @@ var dir_exclude = exists('g:fuzzyy_mru_exclude_dir')
     g:fuzzyy_mru_exclude_dir : g:fuzzyy_exclude_dir
 
 def Preview(wid: number, opts: dict<any>)
-    var result = opts.cursor_item
-    if !has_key(opts.win_opts.partids, 'preview')
+    if wid == -1
         return
     endif
-    var preview_wid = opts.win_opts.partids['preview']
+    var result = opts.cursor_item
     var path = cwd_only ? cwd .. '/' .. result : result
     path = path == '' ? path : fnamemodify(path, ':p')
-    previewer.PreviewFile(preview_wid, path)
-    win_execute(preview_wid, 'norm! gg')
+    previewer.PreviewFile(wid, path)
+    win_execute(wid, 'norm! gg')
 enddef
 
 def Close(wid: number, result: dict<any>)

--- a/autoload/fuzzyy/builtin/mru.vim
+++ b/autoload/fuzzyy/builtin/mru.vim
@@ -18,11 +18,10 @@ var dir_exclude = exists('g:fuzzyy_mru_exclude_dir')
     && type(g:fuzzyy_mru_exclude_dir) == v:t_list ?
     g:fuzzyy_mru_exclude_dir : g:fuzzyy_exclude_dir
 
-def Preview(wid: number, opts: dict<any>)
+def Preview(wid: number, result: string, opts: dict<any>)
     if wid == -1
         return
     endif
-    var result = opts.cursor_item
     var path = cwd_only ? cwd .. '/' .. result : result
     path = path == '' ? path : fnamemodify(path, ':p')
     previewer.PreviewFile(wid, path)

--- a/autoload/fuzzyy/builtin/mru.vim
+++ b/autoload/fuzzyy/builtin/mru.vim
@@ -18,7 +18,7 @@ var dir_exclude = exists('g:fuzzyy_mru_exclude_dir')
     && type(g:fuzzyy_mru_exclude_dir) == v:t_list ?
     g:fuzzyy_mru_exclude_dir : g:fuzzyy_exclude_dir
 
-def Preview(wid: number, result: string, opts: dict<any>)
+def Preview(wid: number, result: string)
     if wid == -1
         return
     endif

--- a/autoload/fuzzyy/builtin/mru.vim
+++ b/autoload/fuzzyy/builtin/mru.vim
@@ -28,15 +28,13 @@ def Preview(wid: number, result: string, opts: dict<any>)
     win_execute(wid, 'norm! gg')
 enddef
 
-def Close(wid: number, result: dict<any>)
-    if has_key(result, 'selected_item')
-        var path = result['selected_item']
-        selector.MoveToUsableWindow()
-        if cwd_only
-            exe 'edit ' cwd .. '/' .. fnameescape(path)
-        else
-            exe 'edit ' .. fnameescape(path)
-        endif
+def Select(wid: number, result: list<any>)
+    var path = result[0]
+    selector.MoveToUsableWindow()
+    if cwd_only
+        exe 'edit ' cwd .. '/' .. fnameescape(path)
+    else
+        exe 'edit ' .. fnameescape(path)
     endif
 enddef
 
@@ -116,7 +114,7 @@ export def Start(opts: dict<any> = {})
     var wids = selector.Start(mru_list, extend(opts, {
         async: true,
         devicons: true,
-        close_cb: function('Close'),
+        select_cb: function('Select'),
         preview_cb: function('Preview'),
         key_callbacks: extend(key_callbacks, selector.split_edit_callbacks),
     }))

--- a/autoload/fuzzyy/builtin/tags.vim
+++ b/autoload/fuzzyy/builtin/tags.vim
@@ -111,11 +111,10 @@ var split_edit_callbacks = {
     "\<c-t>": function('SetTabClose'),
 }
 
-def Preview(wid: number, opts: dict<any>)
+def Preview(wid: number, result: string, opts: dict<any>)
     if wid == -1
         return
     endif
-    var result = opts.cursor_item
     if result == ''
         previewer.PreviewText(wid, '')
         return

--- a/autoload/fuzzyy/builtin/tags.vim
+++ b/autoload/fuzzyy/builtin/tags.vim
@@ -111,7 +111,7 @@ var split_edit_callbacks = {
     "\<c-t>": function('SetTabClose'),
 }
 
-def Preview(wid: number, result: string, opts: dict<any>)
+def Preview(wid: number, result: string)
     if wid == -1
         return
     endif

--- a/autoload/fuzzyy/builtin/tags.vim
+++ b/autoload/fuzzyy/builtin/tags.vim
@@ -57,9 +57,9 @@ def Select(wid: number, result: list<any>)
     endif
 enddef
 
-def CloseTab(wid: number, result: dict<any>)
-    if !empty(get(result, 'cursor_item', ''))
-        var [tagname, tagfile, tagaddress] = ParseResult(result.cursor_item)
+def SelectTab(wid: number, result: list<any>)
+    if !empty(result) && !empty(result[0])
+        var [tagname, tagfile, tagaddress] = ParseResult(result[0])
         var path = ExpandPath(tagfile)
         if filereadable(path)
             exe 'tabnew ' .. fnameescape(path)
@@ -68,9 +68,9 @@ def CloseTab(wid: number, result: dict<any>)
     endif
 enddef
 
-def CloseVSplit(wid: number, result: dict<any>)
-    if !empty(get(result, 'cursor_item', ''))
-        var [tagname, tagfile, tagaddress] = ParseResult(result.cursor_item)
+def SelectVSplit(wid: number, result: list<any>)
+    if !empty(result) && !empty(result[0])
+        var [tagname, tagfile, tagaddress] = ParseResult(result[0])
         var path = ExpandPath(tagfile)
         if filereadable(path)
             exe 'vsplit ' .. fnameescape(path)
@@ -79,9 +79,9 @@ def CloseVSplit(wid: number, result: dict<any>)
     endif
 enddef
 
-def CloseSplit(wid: number, result: dict<any>)
-    if !empty(get(result, 'cursor_item', ''))
-        var [tagname, tagfile, tagaddress] = ParseResult(result.cursor_item)
+def SelectSplit(wid: number, result: list<any>)
+    if !empty(result) && !empty(result[0])
+        var [tagname, tagfile, tagaddress] = ParseResult(result[0])
         var path = ExpandPath(tagfile)
         if filereadable(path)
             exe 'split ' .. fnameescape(path)
@@ -91,18 +91,18 @@ def CloseSplit(wid: number, result: dict<any>)
 enddef
 
 def SetVSplitClose()
-    selector.ReplaceCloseCb(function('CloseVSplit'))
-    selector.Close()
+    selector.ReplaceSelectCb(function('SelectVSplit'))
+    selector.CloseWithSelection()
 enddef
 
 def SetSplitClose()
-    selector.ReplaceCloseCb(function('CloseSplit'))
-    selector.Close()
+    selector.ReplaceSelectCb(function('SelectSplit'))
+    selector.CloseWithSelection()
 enddef
 
 def SetTabClose()
-    selector.ReplaceCloseCb(function('CloseTab'))
-    selector.Close()
+    selector.ReplaceSelectCb(function('SelectTab'))
+    selector.CloseWithSelection()
 enddef
 
 var split_edit_callbacks = {

--- a/autoload/fuzzyy/builtin/tags.vim
+++ b/autoload/fuzzyy/builtin/tags.vim
@@ -112,29 +112,28 @@ var split_edit_callbacks = {
 }
 
 def Preview(wid: number, opts: dict<any>)
-    var result = opts.cursor_item
-    if !has_key(opts.win_opts.partids, 'preview')
+    if wid == -1
         return
     endif
-    var preview_wid = opts.win_opts.partids['preview']
+    var result = opts.cursor_item
     if result == ''
-        previewer.PreviewText(preview_wid, '')
+        previewer.PreviewText(wid, '')
         return
     endif
     var [tagname, tagfile, tagaddress] = ParseResult(result)
     var path = ExpandPath(tagfile)
-    previewer.PreviewFile(preview_wid, path)
+    previewer.PreviewFile(wid, path)
     for excmd in tagaddress->split(";")
         if trim(excmd) =~ '^\d\+$'
-            win_execute(preview_wid, "silent! cursor(" .. excmd .. ", 1)")
+            win_execute(wid, "silent! cursor(" .. excmd .. ", 1)")
         else
             var pattern = excmd->substitute('^\/', '', '')->substitute('\M\/;\?"\?$', '', '')
-            win_execute(preview_wid, "silent! search('\\M" .. EscQuotes(pattern) .. "', 'cw')")
-            clearmatches(preview_wid)
-            win_execute(preview_wid, "silent! matchadd('fuzzyyPreviewMatch', '\\M" .. EscQuotes(pattern) .. "')")
+            win_execute(wid, "silent! search('\\M" .. EscQuotes(pattern) .. "', 'cw')")
+            clearmatches(wid)
+            win_execute(wid, "silent! matchadd('fuzzyyPreviewMatch', '\\M" .. EscQuotes(pattern) .. "')")
         endif
     endfor
-    win_execute(preview_wid, 'norm! zz')
+    win_execute(wid, 'norm! zz')
 enddef
 
 export def Start(opts: dict<any> = {})

--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -188,7 +188,7 @@ def MenuCursorContentChangeCb(): number
 
     if has_key(popup_wins[wins.menu], 'preview_cb')
         if type(popup_wins[wins.menu].preview_cb) == v:t_func
-            popup_wins[wins.menu].preview_cb(wins.preview, {
+            popup_wins[wins.menu].preview_cb(wins.preview, linetext, {
                 cursor_item: linetext,
                 win_opts: has_key(popup_wins, wins.preview) ? popup_wins[wins.preview] : {},
                 last_cursor_item: popup_wins[wins.menu].cursor_item

--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -148,11 +148,10 @@ def GeneralPopupCallback(wid: number, select: any)
 
     # only press enter select will be a list
     if type(select) == v:t_list
-        for Func in popup_wins[wid].close_funcs
-            if type(Func) == v:t_func
-                Func(wid, select)
-            endif
-        endfor
+        if has_key(popup_wins[wid], 'select_cb')
+                && type(popup_wins[wid].select_cb) == v:t_func
+            popup_wins[wid].select_cb(wid, select)
+        endif
     endif
 
     if has_key(popup_wins[wid], 'close_cb')
@@ -435,7 +434,6 @@ def CreatePopup(args: dict<any>): number
         remove(opts, 'border')
     endif
 
-    # we will put user callback in close_funcs, and call it in GeneralPopupCallback
     for key in ['filter', 'border', 'borderhighlight', 'highlight', 'borderchars',
     'scrollbar', 'padding', 'wrap', 'zindex', 'title']
         if has_key(args, key)
@@ -460,7 +458,6 @@ def CreatePopup(args: dict<any>): number
        setwinvar(wid, '&cursorlineopt', 'line')
     endif
     popup_wins[wid] = {
-         close_funcs: [],
          highlights: {},
          noscrollbar_width: noscrollbar_width,
          validrow: 0,
@@ -477,14 +474,11 @@ def CreatePopup(args: dict<any>): number
          prompt_delay_timer: -1,
          }
 
-    for key in ['dropdown', 'reverse_menu', 'preview_cb', 'close_cb']
+    for key in ['dropdown', 'reverse_menu', 'preview_cb', 'close_cb', 'select_cb']
         if has_key(args, key)
             popup_wins[wid][key] = args[key]
         endif
     endfor
-    if has_key(args, 'callback')
-        add(popup_wins[wid].close_funcs, args.callback)
-    endif
     return wid
 enddef
 
@@ -757,7 +751,7 @@ export def PopupSelection(opts: dict<any>): dict<any>
     reverse_menu = has_key(opts, 'reverse_menu') ? opts.reverse_menu : reverse_menu
 
     var menu_opts = {
-        callback: has_key(opts, 'select_cb') ? opts.select_cb : null,
+        select_cb: has_key(opts, 'select_cb') ? opts.select_cb : null,
         close_cb: has_key(opts, 'close_cb') ? opts.close_cb : null,
         preview_cb: has_key(opts, 'preview_cb') ? opts.preview_cb : null,
         scrollbar: has_key(opts, 'scrollbar') ? opts.scrollbar : 0,

--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -296,7 +296,7 @@ def PromptFilter(wid: number, key: string): number
         else
             win_execute(wins.menu, "silent! cursor('$', 1)")
         endif
-        popup_wins[wid].prompt.input_cb(wid, {
+        popup_wins[wid].prompt.input_cb(wid, line_str, {
                 str: line_str,
                 win_opts: popup_wins[wid]})
     endif

--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -156,7 +156,7 @@ def GeneralPopupCallback(wid: number, select: any)
 
     if has_key(popup_wins[wid], 'close_cb')
       && type(popup_wins[wid].close_cb) == v:t_func
-        popup_wins[wid].close_cb(wid, popup_wins[wid])
+        popup_wins[wid].close_cb(wid)
     endif
 
     popup_wins = {}
@@ -177,9 +177,7 @@ def MenuCursorContentChangeCb(): number
 
     if has_key(popup_wins[wins.menu], 'preview_cb')
         if type(popup_wins[wins.menu].preview_cb) == v:t_func
-            popup_wins[wins.menu].preview_cb(wins.preview, linetext,
-                has_key(popup_wins, wins.preview) ? popup_wins[wins.preview] : {}
-            )
+            popup_wins[wins.menu].preview_cb(wins.preview, linetext)
         endif
     endif
     return 1
@@ -282,7 +280,7 @@ def PromptFilter(wid: number, key: string): number
         else
             win_execute(wins.menu, "silent! cursor('$', 1)")
         endif
-        popup_wins[wid].prompt.input_cb(wid, line_str, popup_wins[wid])
+        popup_wins[wid].prompt.input_cb(wid, line_str)
     endif
 
     popup_wins[wid].cursor_args.max_pos = len(line)

--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -188,9 +188,9 @@ def MenuCursorContentChangeCb(): number
 
     if has_key(popup_wins[wins.menu], 'preview_cb')
         if type(popup_wins[wins.menu].preview_cb) == v:t_func
-            popup_wins[wins.menu].preview_cb(wins.menu, {
+            popup_wins[wins.menu].preview_cb(wins.preview, {
                 cursor_item: linetext,
-                win_opts: popup_wins[wins.menu],
+                win_opts: has_key(popup_wins, wins.preview) ? popup_wins[wins.preview] : {},
                 last_cursor_item: popup_wins[wins.menu].cursor_item
                 })
         endif

--- a/autoload/fuzzyy/utils/popup.vim
+++ b/autoload/fuzzyy/utils/popup.vim
@@ -147,9 +147,7 @@ def GeneralPopupCallback(wid: number, select: any)
     active = false
 
     # only press enter select will be a list
-    var has_selection = false
     if type(select) == v:t_list
-        has_selection = true
         for Func in popup_wins[wid].close_funcs
             if type(Func) == v:t_func
                 Func(wid, select)
@@ -159,12 +157,7 @@ def GeneralPopupCallback(wid: number, select: any)
 
     if has_key(popup_wins[wid], 'close_cb')
       && type(popup_wins[wid].close_cb) == v:t_func
-        var opt = {}
-        if has_selection
-            opt.selected_item = select[0]
-        endif
-        opt.cursor_item = popup_wins[wid].cursor_item
-        popup_wins[wid].close_cb(wid, opt)
+        popup_wins[wid].close_cb(wid, popup_wins[wid])
     endif
 
     popup_wins = {}
@@ -182,20 +175,14 @@ def MenuCursorContentChangeCb(): number
     if enable_devicons
         linetext = devicons.RemoveDevicon(linetext)
     endif
-    if popup_wins[wins.menu].cursor_item == linetext
-        return 0
-    endif
 
     if has_key(popup_wins[wins.menu], 'preview_cb')
         if type(popup_wins[wins.menu].preview_cb) == v:t_func
-            popup_wins[wins.menu].preview_cb(wins.preview, linetext, {
-                cursor_item: linetext,
-                win_opts: has_key(popup_wins, wins.preview) ? popup_wins[wins.preview] : {},
-                last_cursor_item: popup_wins[wins.menu].cursor_item
-                })
+            popup_wins[wins.menu].preview_cb(wins.preview, linetext,
+                has_key(popup_wins, wins.preview) ? popup_wins[wins.preview] : {}
+            )
         endif
     endif
-    popup_wins[wins.menu].cursor_item = linetext
     return 1
 enddef
 
@@ -296,9 +283,7 @@ def PromptFilter(wid: number, key: string): number
         else
             win_execute(wins.menu, "silent! cursor('$', 1)")
         endif
-        popup_wins[wid].prompt.input_cb(wid, line_str, {
-                str: line_str,
-                win_opts: popup_wins[wid]})
+        popup_wins[wid].prompt.input_cb(wid, line_str, popup_wins[wid])
     endif
 
     popup_wins[wid].cursor_args.max_pos = len(line)

--- a/autoload/fuzzyy/utils/selector.vim
+++ b/autoload/fuzzyy/utils/selector.vim
@@ -294,8 +294,16 @@ export def ReplaceCloseCb(Close_cb: func)
     popup.SetPopupWinProp(menu_wid, 'close_cb', Close_cb)
 enddef
 
+export def ReplaceSelectCb(Select_cb: func)
+    popup.SetPopupWinProp(menu_wid, 'select_cb', Select_cb)
+enddef
+
 export def Close()
     popup_close(menu_wid)
+enddef
+
+export def CloseWithSelection()
+    popup_close(menu_wid, [MenuGetCursorItem()])
 enddef
 
 export def UpdateList(li: list<string>)
@@ -336,9 +344,9 @@ def Cleanup()
 enddef
 
 # For split callbacks
-def CloseTab(wid: number, result: dict<any>)
-    if !empty(get(result, 'cursor_item', ''))
-        var [buf, line, col] = split(result.cursor_item .. ':0:0', ':')[0 : 2]
+def SelectTab(wid: number, result: list<any>)
+    if !empty(result) && !empty(result[0])
+        var [buf, line, col] = split(result[0] .. ':0:0', ':')[0 : 2]
         var bufnr = bufnr(buf)
         if bufnr > 0 && !filereadable(buf)
             # for special buffers that cannot be edited
@@ -361,9 +369,9 @@ def CloseTab(wid: number, result: dict<any>)
     endif
 enddef
 
-def CloseVSplit(wid: number, result: dict<any>)
-    if !empty(get(result, 'cursor_item', ''))
-        var [buf, line, col] = split(result.cursor_item .. ':0:0', ':')[0 : 2]
+def SelectVSplit(wid: number, result: list<any>)
+    if !empty(result) && !empty(result[0])
+        var [buf, line, col] = split(result[0] .. ':0:0', ':')[0 : 2]
         var bufnr = bufnr(buf)
         if bufnr > 0 && !filereadable(buf)
             # for special buffers that cannot be edited
@@ -387,9 +395,9 @@ def CloseVSplit(wid: number, result: dict<any>)
     endif
 enddef
 
-def CloseSplit(wid: number, result: dict<any>)
-    if !empty(get(result, 'cursor_item', ''))
-        var [buf, line, col] = split(result.cursor_item .. ':0:0', ':')[0 : 2]
+def SelectSplit(wid: number, result: list<any>)
+    if !empty(result) && !empty(result[0])
+        var [buf, line, col] = split(result[0] .. ':0:0', ':')[0 : 2]
         var bufnr = bufnr(buf)
         if bufnr > 0 && !filereadable(buf)
             # for special buffers that cannot be edited
@@ -413,7 +421,7 @@ def CloseSplit(wid: number, result: dict<any>)
     endif
 enddef
 
-def CloseQuickFix(wid: number, result: dict<any>)
+def SelectQuickFix(wid: number, _: list<any>)
     var bufnr = winbufnr(wid)
     var lines: list<any>
     lines = reverse(getbufline(bufnr, 1, "$"))
@@ -439,23 +447,23 @@ def CloseQuickFix(wid: number, result: dict<any>)
 enddef
 
 def SetVSplitClose()
-    ReplaceCloseCb(function('CloseVSplit'))
-    Close()
+    ReplaceSelectCb(function('SelectVSplit'))
+    CloseWithSelection()
 enddef
 
 def SetSplitClose()
-    ReplaceCloseCb(function('CloseSplit'))
-    Close()
+    ReplaceSelectCb(function('SelectSplit'))
+    CloseWithSelection()
 enddef
 
 def SetTabClose()
-    ReplaceCloseCb(function('CloseTab'))
-    Close()
+    ReplaceSelectCb(function('SelectTab'))
+    CloseWithSelection()
 enddef
 
 def SetQuickFixClose()
-    ReplaceCloseCb(function('CloseQuickFix'))
-    Close()
+    ReplaceSelectCb(function('SelectQuickFix'))
+    CloseWithSelection()
 enddef
 
 export var split_edit_callbacks = {

--- a/autoload/fuzzyy/utils/selector.vim
+++ b/autoload/fuzzyy/utils/selector.vim
@@ -163,10 +163,9 @@ def InputAsyncCb(result: list<any>)
     endif
 enddef
 
-def InputAsync(wid: number, opts: dict<any>)
-    var pattern = opts.str
-    if pattern != ''
-        async_tid = FuzzySearchAsync(raw_list, pattern, 200, function('InputAsyncCb'))
+def InputAsync(wid: number, result: string, opts: dict<any>)
+    if result != ''
+        async_tid = FuzzySearchAsync(raw_list, result, 200, function('InputAsyncCb'))
     else
         timer_stop(async_tid)
         var strs = raw_list[: 100]
@@ -303,8 +302,8 @@ export def UpdateList(li: list<string>)
     raw_list = li
 enddef
 
-def Input(wid: number, opts: dict<any>)
-    prompt_str = opts.str
+def Input(wid: number, result: string, opts: dict<any>)
+    prompt_str = result
     menu_hl_list = []
     var ret: list<string>
     [ret, menu_hl_list] = FuzzySearch(raw_list, prompt_str)

--- a/autoload/fuzzyy/utils/selector.vim
+++ b/autoload/fuzzyy/utils/selector.vim
@@ -163,7 +163,7 @@ def InputAsyncCb(result: list<any>)
     endif
 enddef
 
-def InputAsync(wid: number, result: string, opts: dict<any>)
+def InputAsync(wid: number, result: string)
     if result != ''
         async_tid = FuzzySearchAsync(raw_list, result, 200, function('InputAsyncCb'))
     else
@@ -310,7 +310,7 @@ export def UpdateList(li: list<string>)
     raw_list = li
 enddef
 
-def Input(wid: number, result: string, opts: dict<any>)
+def Input(wid: number, result: string)
     prompt_str = result
     menu_hl_list = []
     var ret: list<string>


### PR DESCRIPTION
Adding PR for visibility. The aim here is to simplify the callbacks to make them easier to use.

* Consistent internal names (i.e. remaining references to `move_cb` changed to `select_cb`)
* Clearly separate the responsibilities of close and select callbacks (use close only for cleanup)
* Remove redundant code to create a list of close funcs, this was only used for `select_cb`
* Send relevant window id as first arg to callback, not menu window id (esp. useful for preview callback)
* Send results/selection as separate arg to relevant callbacks (no need to delve into opts dict)
* Remove opts dict from function signatures and when invoking callback functions (not needed anymore)